### PR TITLE
Remove extra white space

### DIFF
--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -171,9 +171,9 @@ var ldclient = LDClient.initialize('YOUR_CLIENT_SIDE_ID', user);
     <CalloutTitle>Initialization delay</CalloutTitle>
   <CalloutDescription>
 
-        Out of the box, initializing the client will make a remote request to LaunchDarkly, so it may take 100 milliseconds
-        or more before the ready event is emitted. If you require feature flag values before rendering the page,
-        we recommend bootstrapping the client. To learn more, read [Bootstrapping](#bootstrapping). If the client is bootstrapped, it will emit the ready event immediately.
+Out of the box, initializing the client will make a remote request to LaunchDarkly, so it may take 100 milliseconds
+or more before the ready event is emitted. If you require feature flag values before rendering the page,
+we recommend bootstrapping the client. To learn more, read [Bootstrapping](#bootstrapping). If the client is bootstrapped, it will emit the ready event immediately.
   
 </CalloutDescription>
 </Callout>


### PR DESCRIPTION
This pr removes the whitespace within the text component that parses the text into a code block. A code block in Markdown, simply requires one to indent every line of the block by at least 4 spaces or 1 tab. Removing these spaces fixes the display issue. 

![image](https://user-images.githubusercontent.com/19398470/74577835-2e38c980-4f46-11ea-89da-3e3d1143c74a.png)
