### PR TITLE
Fix code sample for "Users actions" in custom roles docs

### DIFF
--- a/src/content/topics/home/account-security/custom-roles/actions.mdx
+++ b/src/content/topics/home/account-security/custom-roles/actions.mdx
@@ -763,7 +763,7 @@ For customers with A/B testing, a special resource `integration/optimizely` in c
 <CodeTabItem value="json">
 
 ```json
-member/*:token/*
+proj/*:env/*:user/*
 ```
 
 </CodeTabItem>


### PR DESCRIPTION
Previously it re-used the code sample for member tokens, which is incorrect.