### PR TITLE
Fix typo in navigationData.json

### DIFF
--- a/src/content/navigationData.json
+++ b/src/content/navigationData.json
@@ -60,7 +60,7 @@
             "path": "/home/managing-flags/bulk-user-targeting"
           },
           {
-            "label": "Other flag setttings",
+            "label": "Other flag settings",
             "path": "/home/managing-flags/flag-settings"
           },
           {


### PR DESCRIPTION
Just noticed a small typo in the docs.  Cheers 🙂 