### PR TITLE
Change at code snippet for code ref repository

### DIFF
--- a/src/content/topics/home/account-security/custom-roles/actions.mdx
+++ b/src/content/topics/home/account-security/custom-roles/actions.mdx
@@ -731,7 +731,7 @@ To learn more, read [Data Export](/integrations/data-export).
 <CodeTabItem value="json">
 
 ```json
-member/*
+code-reference-repository/*
 ```
 
 </CodeTabItem>


### PR DESCRIPTION
I think the correct resource specifier was already mentioned under the Code references actions title, which I assume is the correct one. 