### PR TITLE
Added callout to say that require comments is not enforced in API

### DIFF
--- a/src/content/topics/home/managing-flags/environments.mdx
+++ b/src/content/topics/home/managing-flags/environments.mdx
@@ -58,6 +58,14 @@ To add a new environment:
   </CalloutDescription>
 </Callout> 
 
+<Callout intent="warn">
+  <CalloutTitle>Required comments are only enforced in the Dashboard</CalloutTitle>
+  <CalloutDescription>
+    When **Require comments** is enabled, the LaunchDarkly Dashboard will force members to explain their changes. 
+    However, if they make changes via the API, comments will not be required.
+  </CalloutDescription>
+</Callout> 
+
 8. (Optional) Select the **Require confirmation for flag and segment changes** checkbox to force members who modify flags and user segments to verify they wish to make these changes.
 
 <Callout intent="info">

--- a/src/content/topics/home/managing-flags/environments.mdx
+++ b/src/content/topics/home/managing-flags/environments.mdx
@@ -61,8 +61,9 @@ To add a new environment:
 <Callout intent="warn">
   <CalloutTitle>Required comments are only enforced in the Dashboard</CalloutTitle>
   <CalloutDescription>
-    When **Require comments** is enabled, the LaunchDarkly Dashboard will force members to explain their changes. 
-    However, if they make changes via the API, comments will not be required.
+
+When **Require comments** is enabled, the LaunchDarkly Dashboard will force members to explain their changes. Comments are not required for changes made with the LaunchDarkly API.
+    
   </CalloutDescription>
 </Callout> 
 


### PR DESCRIPTION
There has been some confusion with security researchers reporting that comments are not being required in the API.

It turns out this is intentional: https://launchdarkly.atlassian.net/wiki/spaces/ENG/pages/141296222/Require+comments+setting+for+environments#Requirecommentssettingforenvironments-OpenQuestions

Also, it should go without saying, but I'm sure people will ask why we built it like this: It wasn't because we were lazy, it is because it is impossible to force people to leave a *meaningful* comment, so there is no security issue here. The UI prompt is intended to remind people that they should leave a comment. If they are using the API, we assume they know what they are doing.