### PR TITLE
Update name to "Fastly"

### DIFF
--- a/src/content/topics/home/advanced/china.mdx
+++ b/src/content/topics/home/advanced/china.mdx
@@ -9,7 +9,7 @@ published: true
 
 Some customers and users in China have had difficulty maintaining a persistent connection to LaunchDarkly.
 
-While LaunchDarkly is a product with global reach, inconsistencies between the internet services of different countries can make it difficult to predict where we might have outages. Some customers have reported difficulty maintaining a connection to LaunchDarkly from China. We believe this is because of limited support for Fast.ly, a company LaunchDarkly relies upon to provide our services in a timely manner.
+While LaunchDarkly is a product with global reach, inconsistencies between the internet services of different countries can make it difficult to predict where we might have outages. Some customers have reported difficulty maintaining a connection to LaunchDarkly from China. We believe this is because of limited support for Fastly, a company LaunchDarkly relies upon to provide our services in a timely manner.
 
 We offer them the following alternatives to a conventional LaunchDarkly workflow.
 
@@ -29,6 +29,6 @@ To learn more, read [Bootstrapping](/sdk/client-side/javascript#bootstrapping).
 
 To learn more, read [The LaunchDarkly Relay Proxy](/home/advanced/relay-proxy).
 
-* **Pros**: This serves as a replacement for Fast.ly in China, and will be able to serve your clients much faster.
+* **Pros**: This serves as a replacement for Fastly in China, and will be able to serve your clients much faster.
 
 * **Cons**: This is much more complicated to set up than bootstrapping.


### PR DESCRIPTION
The correct name for the service is "Fastly."