### PR TITLE
Correct package name for Go DynamoDB example

### DIFF
--- a/src/content/topics/sdk/concepts/feature-store.mdx
+++ b/src/content/topics/sdk/concepts/feature-store.mdx
@@ -621,12 +621,12 @@ import (
 ) 
 
 
-store, err := ldredis.NewDynamoDBFeatureStore("my-table",
+store, err := lddynamodb.NewDynamoDBFeatureStoreFactory("my-table", 
     lddynamodb.CacheTTL(30 * time.Second)) 
 
 
 config := ld.DefaultConfig
-config.FeatureStore = store
+config.FeatureStoreFactory = store
 client := ld.MakeCustomClient(sdkKey, config, waitTime) 
 
 ```


### PR DESCRIPTION
* Correct package name (use `lddynamodb` instead of `ldredis`
* Use `FeatureStoreFactory` instead of deprecated `FeatureStore`