### PR TITLE
Update evaluation-reasons.mdx

### DIFF
--- a/src/content/topics/sdk/concepts/evaluation-reasons.mdx
+++ b/src/content/topics/sdk/concepts/evaluation-reasons.mdx
@@ -212,9 +212,8 @@ These values are:
         <code>OFF</code>
       </TableCell>
       <TableCell>
-        The flag is on, but the user did not match any targets or rules, so it returned the value that appears on the
-        dashboard under "Default rule." The "default rule" is not the same thing as the default value discussed in
-        "Error conditions".
+        The flag is off and therefore returned its configured off value. This value appears on the dashboard next to "If
+        targeting is off, serve: ".
       </TableCell>
     </TableRow>
     <TableRow>
@@ -222,8 +221,9 @@ These values are:
         <code>FALLTHROUGH</code>
       </TableCell>
       <TableCell>
-        The flag is off and therefore returned its configured off value. This value appears on the dashboard next to "If
-        targeting is off, serve: ".
+        The flag is on, but the user did not match any targets or rules, so it returned the value that appears on the
+        dashboard under "Default rule." The "default rule" is not the same thing as the default value discussed in
+        "Error conditions".
       </TableCell>
     </TableRow>
     <TableRow>


### PR DESCRIPTION
Swap explanations for `FALLTHROUGH` and `OFF` in `Understanding the reason data` so that the correct explanation is provided.