### PR TITLE
Updated URL in Sleuth integration page

### DIFF
--- a/src/content/topics/integrations/sleuth.mdx
+++ b/src/content/topics/integrations/sleuth.mdx
@@ -93,13 +93,13 @@ To remove the Sleuth integration:
 
 ![Deleting the LaunchDarkly integration in Sleuth](../images/sleuth-ld-integration-delete_2.png)
 
-This removes the LaunchDarkly integation.
+This removes the LaunchDarkly integration.
 
 ## Getting Slack notifications from Sleuth
 
 With the Slack integration in Sleuth, you can notify your entire team, or just the commit author or PR initiator, of a code change. This includes feature flag changes. 
 
-To learn more, read <a href="https://help.sleuth.io/integrations/slack">Sleuth's documentation</a>. 
+To learn more, read <a href="https://help.sleuth.io/integrations-1/chat-ops/slack">Sleuth's documentation</a>. 
 
 The Sleuth Slack integration works independently from the LaunchDarkly Slack integration. If you use both, you may see notifications from both Sleuth and LaunchDarkly about flag activity. 
 


### PR DESCRIPTION
Update to two lines: 
line 96: typo 'integation';
line 102: URL on Sleuth docs site changed due to new slug.