### PR TITLE
Fix formatting for "Require Comments" warning

### DIFF
--- a/src/content/topics/home/managing-flags/environments.mdx
+++ b/src/content/topics/home/managing-flags/environments.mdx
@@ -61,9 +61,8 @@ To add a new environment:
 <Callout intent="warn">
   <CalloutTitle>Required comments are only enforced in the Dashboard</CalloutTitle>
   <CalloutDescription>
-
-When **Require comments** is enabled, the LaunchDarkly Dashboard will force members to explain their changes. Comments are not required for changes made with the LaunchDarkly API.
-    
+    When **Require comments** is enabled, the LaunchDarkly Dashboard will force members to explain their changes. 
+    Comments are not required for changes made with the LaunchDarkly API.   
   </CalloutDescription>
 </Callout> 
 


### PR DESCRIPTION
Changes here tweak a `Callout` element such that it renders correctly. The current published state looks like:
![Screen Shot 2020-05-27 at 11 21 45](https://user-images.githubusercontent.com/29710511/83046180-44a5f500-a00c-11ea-9768-ba1639157f46.png)

From https://docs.launchdarkly.com/home/managing-flags/environments