### PR TITLE
Fix Callout intent type from "warn" to "warning"

### DIFF
--- a/src/content/topics/home/managing-flags/environments.mdx
+++ b/src/content/topics/home/managing-flags/environments.mdx
@@ -58,7 +58,7 @@ To add a new environment:
   </CalloutDescription>
 </Callout> 
 
-<Callout intent="warn">
+<Callout intent="warning">
   <CalloutTitle>Required comments are only enforced in the Dashboard</CalloutTitle>
   <CalloutDescription>
 


### PR DESCRIPTION
Updates the intent type for one of the Callouts to be "warning" instead of "warn". The current published formatting looks like:
![Screen Shot 2020-05-27 at 11 21 45](https://user-images.githubusercontent.com/29710511/83047602-3527ab80-a00e-11ea-83cc-2836148f062a.png)

From https://docs.launchdarkly.com/home/managing-flags/environments