### PR TITLE
Add more detail to mParticle data export examples

### DIFF
--- a/src/content/topics/home/changelog.mdx
+++ b/src/content/topics/home/changelog.mdx
@@ -15,6 +15,19 @@ This topic summarizes changes made to the LaunchDarkly documentation site. Use t
     <TableHeadCell>Github PR</TableHeadCell>
   </TableHeader>
   <TableBody>
+   <TableRow>
+      <TableCell> May 29, 2020 </TableCell>
+      <TableCell>Updates examples in Data Export docs to clarify placeholder content and add detail.</TableCell>
+
+<TableCell>
+
+<a href="/integrations/data-export/mparticle">mParticle</a><br/><br/>
+
+<a href="/integrations/data-export/segment">Segment</a>
+
+</TableCell>
+      <TableCell><a href="https://github.com/launchdarkly/LaunchDarkly-Docs/pull/55">PR #55</a></TableCell>
+    </TableRow>
   <TableRow>
     <TableCell>May 21, 2020</TableCell>
       <TableCell>Publishes a new category of content that explains how and why to use LaunchDarkly features.</TableCell>

--- a/src/content/topics/integrations/data-export/mparticle.mdx
+++ b/src/content/topics/integrations/data-export/mparticle.mdx
@@ -117,12 +117,28 @@ LaunchDarkly sends events in the following formats:
 ```json
 {
   "user_identities": {
-    "customer_id": "example_user"
+    "customer_id": "example_customer"
   },
   "environment": "production",
   "events": [
     {
-      "event_type": "custom_event"
+      "event_type": "custom_event",
+      "data": {
+        "source_message_id": "###-##",
+        "event_name": "feature",
+        "timestamp_unixtime_ms": 1590697814783,
+        "custom_event_type": "other",
+        "custom_attributes": {
+          "project": "project",
+          "environment": "environmentId",
+          "version": "1",
+          "key": "flag",
+          "value": "true",
+          "flag_version": "42",
+          "default": "false",
+          "reason_kind": "FALLTHROUGH",
+          "prerequisite_of": "parent flag"
+        }
       }
     }
   ]
@@ -171,7 +187,18 @@ LaunchDarkly sends events in the following formats:
   "environment": "production",
   "events": [
     {
-      "event_type": "custom_event"
+      "event_type": "custom_event",
+      "data": {
+        "source_message_id": "###-##",
+        "event_name": "custom",
+        "timestamp_unixtime_ms": 1590698576956,
+        "custom_event_type": "other",
+        "custom_attributes": {
+          "project": "project",
+          "environment": "environmentId",
+          "version": "1",
+          "key": "custom-event-key"
+        }
       }
     }
   ]
@@ -189,7 +216,18 @@ LaunchDarkly sends events in the following formats:
   "environment": "production",
   "events": [
     {
-      "event_type": "screen_view"
+      "event_type": "screen_view",
+      "data": {
+        "source_message_id": "###-##",
+        "screen_name": "http://example.com",
+        "timestamp_unixtime_ms": 1590698654895,
+        "custom_attributes": {
+          "project": "project",
+          "environment": "environmentId",
+          "version": "1",
+          "key": "pageview-event-key",
+          "url": "http://example.com?queryParam=this"
+        }
       }
     }
   ]

--- a/src/content/topics/integrations/data-export/mparticle.mdx
+++ b/src/content/topics/integrations/data-export/mparticle.mdx
@@ -130,7 +130,7 @@ LaunchDarkly sends events in the following formats:
         "custom_event_type": "other",
         "custom_attributes": {
           "project": "project",
-          "environment": "environmentId",
+          "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
           "key": "flag",
           "value": "true",
@@ -164,7 +164,7 @@ LaunchDarkly sends events in the following formats:
         "custom_event_type": "navigation",
         "custom_attributes": {
           "project": "project",
-          "environment": "environmentID",
+          "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
           "key": "click-event-key",
           "selector": "btn",
@@ -195,7 +195,7 @@ LaunchDarkly sends events in the following formats:
         "custom_event_type": "other",
         "custom_attributes": {
           "project": "project",
-          "environment": "environmentId",
+          "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
           "key": "custom-event-key"
         }
@@ -223,7 +223,7 @@ LaunchDarkly sends events in the following formats:
         "timestamp_unixtime_ms": 1590698654895,
         "custom_attributes": {
           "project": "project",
-          "environment": "environmentId",
+          "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
           "key": "pageview-event-key",
           "url": "http://example.com?queryParam=this"

--- a/src/content/topics/integrations/data-export/mparticle.mdx
+++ b/src/content/topics/integrations/data-export/mparticle.mdx
@@ -117,19 +117,19 @@ LaunchDarkly sends events in the following formats:
 ```json
 {
   "user_identities": {
-    "customer_id": "example_customer"
+    "customer_id": "EXAMPLE-CUSTOMER"
   },
-  "environment": "production",
+  "environment": "EXAMPLE-ENVIRONMENT-NAME",
   "events": [
     {
-      "event_type": "custom_event",
+      "event_type": "CUSTOM-EVENT",
       "data": {
         "source_message_id": "###-##",
-        "event_name": "feature",
+        "event_name": "EXAMPLE-FEATURE-NAME",
         "timestamp_unixtime_ms": 1590697814783,
         "custom_event_type": "other",
         "custom_attributes": {
-          "project": "project",
+          "project": "EXAMPLE-PROJECT-NAME",
           "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
           "key": "flag",
@@ -137,7 +137,7 @@ LaunchDarkly sends events in the following formats:
           "flag_version": "42",
           "default": "false",
           "reason_kind": "FALLTHROUGH",
-          "prerequisite_of": "parent flag"
+          "prerequisite_of": "PARENT-FLAG"
         }
       }
     }
@@ -151,12 +151,12 @@ LaunchDarkly sends events in the following formats:
 ```json
 {
   "user_identities": {
-    "customer_id": "example_customer"
+    "customer_id": "EXAMPLE-CUSTOMER"
   },
-  "environment": "production",
+  "environment": "EXAMPLE-ENVIRONMENT-NAME",
   "events": [
     {
-      "event_type": "custom_event",
+      "event_type": "CUSTOM-EVENT",
       "data": {
         "source_message_id": "###-##",
         "event_name": "click",
@@ -166,7 +166,7 @@ LaunchDarkly sends events in the following formats:
           "project": "project",
           "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
-          "key": "click-event-key",
+          "key": "EXAMPLE-CLICK-EVENT-KEY",
           "selector": "btn",
           "url": "http://example.com?queryParam=this"
         }
@@ -182,9 +182,9 @@ LaunchDarkly sends events in the following formats:
 ```json
 {
   "user_identities": {
-    "customer_id": "example_customer"
+    "customer_id": "EXAMPLE-CUSTOMER"
   },
-  "environment": "production",
+  "environment": "EXAMPLE-ENVIRONMENT-NAME",
   "events": [
     {
       "event_type": "custom_event",
@@ -197,7 +197,7 @@ LaunchDarkly sends events in the following formats:
           "project": "project",
           "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
-          "key": "custom-event-key"
+          "key": "EXAMPLE-CUSTOM-EVENT-KEY",
         }
       }
     }
@@ -211,9 +211,9 @@ LaunchDarkly sends events in the following formats:
 ```json
 {
   "user_identities": {
-    "customer_id": "example_customer"
+    "customer_id": "EXAMPLE-CUSTOMER"
   },
-  "environment": "production",
+  "environment": "EXAMPLE-ENVIRONMENT-NAME",
   "events": [
     {
       "event_type": "screen_view",
@@ -225,7 +225,7 @@ LaunchDarkly sends events in the following formats:
           "project": "project",
           "environment": "5d4b12345d2a2806bd2cc6eb",
           "version": "1",
-          "key": "pageview-event-key",
+          "key": "EXAMPLE-PAGEVIEW-EVENT-KEY",
           "url": "http://example.com?queryParam=this"
         }
       }

--- a/src/content/topics/integrations/data-export/segment.mdx
+++ b/src/content/topics/integrations/data-export/segment.mdx
@@ -87,18 +87,18 @@ LaunchDarkly sends events in the following formats:
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c12345a51a0006e16ae5",
     "flagVersion": 42,
-    "key": "flag-key",
-    "prereqOf": "example-parent-flag",
+    "key": "EXAMPLE-FLAG-KEY",
+    "prereqOf": "EXAMPLE-PARENT-FLAG",
     "project": "5744c12345c9900708000001",
     "reasonKind": "FALLTHROUGH",
-    "value": "example-flag-value",
+    "value": "EXAMPLE-FLAG-VALUE",
     "version": 1
   },
   "receivedAt": "2019-09-13T21:20:19.406Z",
   "sentAt": "2019-09-13T21:20:19.366Z",
   "timestamp": "2019-09-13T21:20:18.153Z",
   "type": "track",
-  "userId": "example-user-id",
+  "userId": "EXAMPLE-USER-ID",
 }
 ```
 
@@ -124,7 +124,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c123a86f26000065862da",
-    "key": "flag-key",
+    "key": "EXAMPLE-FLAG-KEY",
     "project": "5744c98765c9900708000001",
     "selector": "btn",
     "url": "http://example.com",
@@ -134,7 +134,7 @@ LaunchDarkly sends events in the following formats:
   "sentAt": "2019-09-13T21:21:46.375Z",
   "timestamp": "2019-09-13T21:21:43.154Z",
   "type": "track",
-  "userId": "example-user-id",
+  "userId": "EXAMPLE-USER-ID",
 }
 ```
 
@@ -159,7 +159,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c123452db400061b14dd",
-    "key": "event-key",
+    "key": "EXAMPLE-EVENT-KEY",
     "project": "5744c12345c9900708000001",
     "version": 1
   },
@@ -167,7 +167,7 @@ LaunchDarkly sends events in the following formats:
   "sentAt": "2019-09-13T21:22:00.393Z",
   "timestamp": "2019-09-13T21:21:58.393Z",
   "type": "track",
-  "userId": "example-user-id",
+  "userId": "EXAMPLE-USER-ID",
 }
 
 ```
@@ -191,7 +191,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d123454d2a2806bd2cc6eb",
     "eventId": "5d7c12345db400061b14c1",
-    "key": "flag-key",
+    "key": "EXAMPLE-FLAG-KEY",
     "project": "5744c123459900708000001",
     "url": "http://example.com",
     "version": 1
@@ -200,7 +200,7 @@ LaunchDarkly sends events in the following formats:
   "sentAt": "2019-09-13T21:19:45.331Z",
   "timestamp": "2019-09-13T21:19:43.154Z",
   "type": "page",
-  "userId": "example-user-id",
+  "userId": "EXAMPLE-USER-ID",
 }
 ```
 

--- a/src/content/topics/integrations/data-export/segment.mdx
+++ b/src/content/topics/integrations/data-export/segment.mdx
@@ -87,8 +87,8 @@ LaunchDarkly sends events in the following formats:
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c12345a51a0006e16ae5",
     "flagVersion": 42,
-    "key": "b2dee41d-a10b-4f57-855b-10239fb28bec",
-    "prereqOf": "example parent flag",
+    "key": "flag-key",
+    "prereqOf": "example-parent-flag",
     "project": "5744c12345c9900708000001",
     "reasonKind": "FALLTHROUGH",
     "value": "example-flag-value",
@@ -124,7 +124,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c123a86f26000065862da",
-    "key": "5d7c12345a0c92071ec8963d",
+    "key": "flag-key",
     "project": "5744c98765c9900708000001",
     "selector": "btn",
     "url": "http://example.com",
@@ -159,7 +159,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d4b12345d2a2806bd2cc6eb",
     "eventId": "5d7c123452db400061b14dd",
-    "key": "90f49c28-0a1b-4187-b196-de0e8f57a5a7",
+    "key": "event-key",
     "project": "5744c12345c9900708000001",
     "version": 1
   },
@@ -191,7 +191,7 @@ LaunchDarkly sends events in the following formats:
   "properties": {
     "environment": "5d123454d2a2806bd2cc6eb",
     "eventId": "5d7c12345db400061b14c1",
-    "key": "5d7c071234592071ec8954d",
+    "key": "flag-key",
     "project": "5744c123459900708000001",
     "url": "http://example.com",
     "version": 1

--- a/src/content/topics/integrations/data-export/segment.mdx
+++ b/src/content/topics/integrations/data-export/segment.mdx
@@ -27,7 +27,7 @@ To find the write key:
 3. Select **API Keys** on the Source integration's menu bar
 4. Copy the **Write Key** as shown in the text box
 
-![The API Keys section of Segment's UI.](../../images/integrations-segment-write-key.png) 
+![The API Keys section of Segment's UI.](../../images/integrations-segment-write-key.png)
 
 
 ## Creating a Segment destination in LaunchDarkly
@@ -42,7 +42,7 @@ To create the Segment destination:
 6. Enter the Segment **Write key**.
 7. Click **Save Destination**. The new integration appears in the list of integrations.
 
-![The "Create a Destination" screen.](../../images/integrations-segment-create.png) 
+![The "Create a Destination" screen.](../../images/integrations-segment-create.png)
 
 
 ## Testing a Segment destination
@@ -55,7 +55,7 @@ To test the Segment destination:
 2. Find the Segment destination and click **Edit**. The "Edit destination" screen opens.
 3. Click **Send Event** in the "Send a test event" section.
 
-![The Send a test event section of the Edit destination screen.](../../images/integrations-segment-test-event.png) 
+![The Send a test event section of the Edit destination screen.](../../images/integrations-segment-test-event.png)
 
 
 4. Verify the event appears in the Segment **Debugger**.
@@ -223,5 +223,5 @@ To delete a destination:
 2. Find the destination you wish to delete and click **Edit**. The "Create a destination" screen opens.
 3. Click **Delete Destination**.
 
-![The Delete destination section.](../../images/integrations-segment-delete.png) 
+![The Delete destination section.](../../images/integrations-segment-delete.png)
 


### PR DESCRIPTION
Adds more detail to `feature`, `click`, and `page_view` event examples. The `custom` event example already contains sufficient detail.

Also updates Segment examples to be a bit clearer