### PR TITLE
Move `eventsUri` var under new file section `Events`

### DIFF
--- a/src/content/topics/home/advanced/relay-proxy/using.mdx
+++ b/src/content/topics/home/advanced/relay-proxy/using.mdx
@@ -51,6 +51,8 @@ go get -u gopkg.in/launchdarkly/ld-relay.v5/...
 [main]
     streamUri = "https://stream.launchdarkly.com"
     baseUri = "https://app.launchdarkly.com"
+
+[events]
     eventsUri = "https://events.launchdarkly.com"
 
 [environment "<YOUR-ENVIRONMENT'S-NAME>"]
@@ -76,6 +78,8 @@ You can connect your Relay Proxy to multiple LaunchDarkly environments by specif
 [main]
     streamUri = "https://stream.launchdarkly.com"
     baseUri = "https://app.launchdarkly.com"
+
+[events]
     eventsUri = "https://events.launchdarkly.com"
 
 [environment "Spree Webapp Production"]


### PR DESCRIPTION
According to official `ld-relay` docs, the `eventsUri` variable must be under the `Events` file section.
https://github.com/launchdarkly/ld-relay#file-section-events