### PR TITLE
Update Sleuth integration instruction

### DIFF
--- a/src/content/topics/integrations/sleuth.mdx
+++ b/src/content/topics/integrations/sleuth.mdx
@@ -32,8 +32,8 @@ The integration is initiated from your Sleuth account. After you connect it, you
 To connect the Sleuth integration with LaunchDarkly:
 
 1. Log into your [Sleuth Dashboard](https://app.sleuth.io/accounts/login/).
-2. In the left sidebar, click the **Create** dropdown, then click **Add feature flags**.
-3. Click **Enable LaunchDarkly feature flags**. 
+2. In the left sidebar, click **Integrations**.
+3. Click **enable** in the LaunchDarkly card in the **Change Sources** tab.  
 4. Click **Authorize**. This allows Sleuth to read and modify your LaunchDarkly data. 
 
 <Callout intent="info">
@@ -45,7 +45,7 @@ To connect the Sleuth integration with LaunchDarkly:
 
 ![The LaunchDarkly authorization dialog.](../images/sleuth-ld-integration-auth-dialog.png)
 
-5. Confirm that the integration has connected LaunchDarkly and Sleuth by finding the **LaunchDarkly feature flags enabled** button in the Sleuth integration card.
+5. Confirm that the integration has connected LaunchDarkly and Sleuth when **LaunchDarkly enabled (Connected as user)** is displayed in the LaunchDarkly integration card.
 
 ![A successfully connected integration.](../images/sleuth-ld-integration-success-dialog_3.png)
 
@@ -85,9 +85,9 @@ After the connection is established, the Sleuth trend graph appears. Use this gr
 To remove the Sleuth integration:
 
 1. Log in to your Sleuth account.
-2. Click the gear icon in the upper-right corner of the dashboard. 
-3. Click **Delete**. A confirmation screen appears.
-4. Click **Delete** again to confirm. 
+2. In the left sidebar, click **Integrations**.
+3. Click **disable** in the LaunchDarkly card in the **Change Sources** tab.  
+4. Confirm that the integration has been removed when **LaunchDarkly disabled - enable** is displayed in the LaunchDarkly integration card.
 
 ![Deleting the LaunchDarkly integration in Sleuth](../images/sleuth-ld-integration-delete_2.png)
 


### PR DESCRIPTION
We've been tweaking our UI quite a bit in the last month; our new Ux hire has been busy! I've updated integration instructions to make it simpler to enable/disable our integration. You can now get to the LD integration card more quickly after login; the initial procedure had an extra step. Also, we've changed our convention from 'connect/disconnect' to 'enable/disable'. :) Feel free to make additional edits as needed. 