### PR TITLE
Clarify clientside ID in Segment auth

### DIFF
--- a/src/content/topics/home/experimentation/segment.mdx
+++ b/src/content/topics/home/experimentation/segment.mdx
@@ -9,7 +9,7 @@ published: true
 
 This topic explains how to configure your existing Segment account to send events to LaunchDarkly experiments.
 
-This lets you use Segment events as custom metric events in LaunchDarkly experiments, so you can measure results immediately, without any instrumentation, code, or delays. 
+This lets you use Segment events as custom metric events in LaunchDarkly experiments, so you can measure results immediately, without any instrumentation, code, or delays.
 
 After you connect LaunchDarkly and Segment, you can use the name of the existing Segment event when you create a custom metric to include it in your experiment immediately.
 
@@ -23,7 +23,7 @@ To set up the integration, you must have access to your Segment and LaunchDarkly
 
 1. Log in to LaunchDarkly and click into the **Account Settings** page.
 2. Click into the **Authorization** tab.
-3. Create and copy the client-side ID from the default project. This enables all experiments running in LaunchDarkly to receive Segment track events.
+3. Create and copy the client-side ID from the desired environment. This enables all experiments running in the chosen LaunchDarkly environment to receive Segment track events.
 
 ### Connecting Segment to LaunchDarkly
 


### PR DESCRIPTION
Clarifies the meaning of client-side ID chosen when configuring the Segment destination.

Could use a double check on the correctness of this statement