### PR TITLE
JS Client SDK: Add callout to use evaluationDetails option in variationDetail section

### DIFF
--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -601,8 +601,8 @@ The `variationDetail` method allows you to evaluate a feature flag (using the sa
 <Callout intent="alert">
   <CalloutTitle>Don't forget</CalloutTitle>
 <CalloutDescription>
-You must enable `evaluationReasons` option when intializing the LaunchDarkly client or the `reason` object returned by this method will always be null.
-  
+You must enable the `evaluationReasons` option when intializing the LaunchDarkly client or the `reason` object returned by this method will always be null.
+
 To learn more, read [Customizing your client](#customizing-your-client).
 </CalloutDescription>
 </Callout>

--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -599,9 +599,9 @@ The default value will only be returned if an error is encountered—for example
 The `variationDetail` method allows you to evaluate a feature flag (using the same parameters as you would for `variation`) and receive more information about how the value was calculated.
 
 <Callout intent="alert">
-  <CalloutTitle>Don't forget</CalloutTitle>
+  <CalloutTitle>You must enable the evaluationReasons option</CalloutTitle>
 <CalloutDescription>
-You must enable the `evaluationReasons` option when intializing the LaunchDarkly client or the `reason` object returned by this method will always be null.
+You must enable the `evaluationReasons` option when you initialize the LaunchDarkly client. If you do not do this, the `reason` object returned by this method will always be null.
 
 To learn more, read [Customizing your client](#customizing-your-client).
 </CalloutDescription>

--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -598,6 +598,15 @@ The default value will only be returned if an error is encountered—for example
 
 The `variationDetail` method allows you to evaluate a feature flag (using the same parameters as you would for `variation`) and receive more information about how the value was calculated.
 
+<Callout intent="alert">
+  <CalloutTitle>Don't forget</CalloutTitle>
+<CalloutDescription>
+You must enable `evaluationReasons` option when intializing the LaunchDarkly client or the `reason` object returned by this method will always be null.
+  
+To learn more, read [Customizing your client](#customizing-your-client).
+</CalloutDescription>
+</Callout>
+
 The variation detail is returned in an object that contains both the result value and a "reason" object which will tell you, for instance, if the user was individually targeted for the flag or was matched by one of the flag's rules. It will also indicate if the flag returned the default value due to an error.
 
 You can examine the "reason" data programmatically; you can also view it with data export, if you are capturing detailed analytics events for this flag.


### PR DESCRIPTION
Today, while implementing some functionality to use `variationDetail` calls to examine and respond to flag evaluation reasons, I missed the requirement that you must set the `evaluationReasons` option to true for `detail.reason` to be populated in the JS Client SDK.

This PR adds a callout to the docs reminding readers to enable that option if they wish to access Evaluation Reasons from the SDK.