### PR TITLE
Update feature-workflows.mdx

### DIFF
--- a/src/content/topics/home/managing-flags/feature-workflows.mdx
+++ b/src/content/topics/home/managing-flags/feature-workflows.mdx
@@ -9,7 +9,7 @@ published: true
 <CalloutTitle>Feature Workflows is an Enterprise feature</CalloutTitle>
 <CalloutDescription>
 
-Feature Workflows is only available to customers on Enterprise plans. To learn more about our plans, [read about our pricing](https://launchdarkly.com/pricing). To upgrade your account to an Enterpirse plan, [contact our Sales team](mailto:sales@launchdarkly.com).
+Feature Workflows is only available to customers on Enterprise plans. To learn more about our plans, [read about our pricing](https://launchdarkly.com/pricing). To upgrade your account to an Enterprise plan, [contact our Sales team](mailto:sales@launchdarkly.com).
 
 </CalloutDescription>
 </Callout>

--- a/src/content/topics/home/managing-flags/feature-workflows.mdx
+++ b/src/content/topics/home/managing-flags/feature-workflows.mdx
@@ -9,7 +9,7 @@ published: true
 <CalloutTitle>Feature Workflows is an Enterprise feature</CalloutTitle>
 <CalloutDescription>
 
-Feature Workflows is only available to customers on Enterprise plans. To learn more about our plans, [read about our pricing](https://launchdarkly.com/pricing). If you want to add Feature Workflows to an existing plan, [contact our Sales team](mailto:sales@launchdarkly.com).
+Feature Workflows is only available to customers on Enterprise plans. To learn more about our plans, [read about our pricing](https://launchdarkly.com/pricing). To upgrade your account to an Enterpirse plan, [contact our Sales team](mailto:sales@launchdarkly.com).
 
 </CalloutDescription>
 </Callout>


### PR DESCRIPTION
updating the Enterprise plan alert to make it more clear that you cannot add Feature Workflows to your account like a typical add-on, you must upgrade to Enterprise.