### PR TITLE
Correcting the trigger flag/environment reference

### DIFF
--- a/src/content/topics/integrations/triggers.mdx
+++ b/src/content/topics/integrations/triggers.mdx
@@ -104,7 +104,7 @@ You can create triggers for individual feature flags from the flag's **Settings*
 To create a trigger:
 
 1. Navigate to the feature flag for which you wish to create a trigger, and click into its **Settings** page.
-2. Find the "Triggers for [Flag Name]" section and click **Add trigger**. The "Create trigger" dialog box appears.
+2. Find the "Triggers for [Environment Name]" section and click **Add trigger**. The "Create trigger" dialog box appears.
 
 ![The "Create trigger" dialog box.](../../images/triggers-create.png)
 


### PR DESCRIPTION
As shown in the screenshot right next to this text, the variable is an _environment name_ rather than a _flag name_.