### PR TITLE
Fix Go SDK API docs link

### DIFF
--- a/src/content/topics/sdk/server-side/go/index.mdx
+++ b/src/content/topics/sdk/server-side/go/index.mdx
@@ -5,7 +5,7 @@ description: 'This topic explains all of the methods available in the server-sid
 published: true
 ---
 
-This reference guide documents all of the methods available in our Go SDK, and explains in detail how these methods work. If you want to dig even deeper, our SDKs are open source. To learn more, read [Go SDK GitHub repository](https://github.com/launchdarkly/go-server-sdk). The online [Go API docs](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk) contain the programmatic definitions of every type and method. Additionally you can clone and run a [sample application](https://github.com/launchdarkly/hello-go) using this SDK.
+This reference guide documents all of the methods available in our Go SDK, and explains in detail how these methods work. If you want to dig even deeper, our SDKs are open source. To learn more, read [Go SDK GitHub repository](https://github.com/launchdarkly/go-server-sdk). The online [Go API docs](https://pkg.go.dev/gopkg.in/launchdarkly/go-server-sdk.v5) contain the programmatic definitions of every type and method. Additionally you can clone and run a [sample application](https://github.com/launchdarkly/hello-go) using this SDK.
 
 <Callout intent="info">
   <CalloutTitle>Go version compatibility</CalloutTitle>


### PR DESCRIPTION
The existing link points to the wrong version of the API docs.