### PR TITLE
Update Python instantiation steps

### DIFF
--- a/src/content/topics/sdk/server-side/python.mdx
+++ b/src/content/topics/sdk/server-side/python.mdx
@@ -45,6 +45,23 @@ import ldclient
 </CodeTabItem>
 </CodeTabs>
 
+Additionally, you will need to pass a `Config` object to the `ldclient.set_config` method to instantiate your client instance. You can import the `Config` object with this line:
+
+<CodeTabs
+  defaultValue="py"
+  values={[
+    { label: 'Python', value: 'py', },
+  ]
+}>
+<CodeTabItem value="py">
+
+```py
+from ldclient.config import Config
+```
+
+</CodeTabItem>
+</CodeTabs>
+
 Once the SDK is installed and imported, you'll want to create a single, shared instance of `ldclient`. The `get()` function enforces the singleton pattern; you should only have one instance of the client in your application. You should specify your SDK key here so that your application will be authorized to connect to LaunchDarkly and for your application and environment.
 
 <CodeTabs
@@ -56,7 +73,9 @@ Once the SDK is installed and imported, you'll want to create a single, shared i
 <CodeTabItem value="py">
 
 ```py
-ldclient.set_sdk_key("YOUR_SDK_KEY")
+sdk_key="YOUR_SDK_KEY"
+
+ldclient.set_config(Config(sdk_key))
 ld_client = ldclient.get()
 ```
 

--- a/src/content/topics/sdk/server-side/python.mdx
+++ b/src/content/topics/sdk/server-side/python.mdx
@@ -40,22 +40,6 @@ Next you should import the LaunchDarkly client in your application code.
 
 ```py
 import ldclient
-```
-
-</CodeTabItem>
-</CodeTabs>
-
-Additionally, you will need to pass a `Config` object to the `ldclient.set_config` method to instantiate your client instance. You can import the `Config` object with this line:
-
-<CodeTabs
-  defaultValue="py"
-  values={[
-    { label: 'Python', value: 'py', },
-  ]
-}>
-<CodeTabItem value="py">
-
-```py
 from ldclient.config import Config
 ```
 

--- a/src/content/topics/sdk/server-side/python.mdx
+++ b/src/content/topics/sdk/server-side/python.mdx
@@ -73,9 +73,7 @@ Once the SDK is installed and imported, you'll want to create a single, shared i
 <CodeTabItem value="py">
 
 ```py
-sdk_key="YOUR_SDK_KEY"
-
-ldclient.set_config(Config(sdk_key))
+ldclient.set_config(Config("YOUR_SDK_KEY"))
 ld_client = ldclient.get()
 ```
 


### PR DESCRIPTION
According to https://github.com/launchdarkly/python-server-sdk/blob/20ccf1536b51972a807c21b7d8eb097f26c28f53/CHANGELOG.md#700---2020-10-28, the set_sdk_key method no longer exists. Instead, a client must be instantiated using a config object. The sample code fails as is, so I've tried to update it to the best of my abilities.