### PR TITLE
reword relay proxy intro

### DIFF
--- a/src/content/topics/home/advanced/relay-proxy/index.mdx
+++ b/src/content/topics/home/advanced/relay-proxy/index.mdx
@@ -9,9 +9,9 @@ published: true
 
 This topic explains what the Relay Proxy is and how to use it.
 
-The Relay Proxy is a small Go application that connects to the LaunchDarkly streaming API and proxies that connection to clients within an organziation's network.
+The Relay Proxy is a small Go application that connects to the LaunchDarkly streaming API and proxies that connection to clients within an organization's network.
 
-The Relay Proxy lets private servers connect to a local stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
+The Relay Proxy lets multiple servers connect to a local, private stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
 
 The Relay Proxy is an open-source project supported by LaunchDarkly. The full source is in a [GitHub repository](https://github.com/launchdarkly/ld-relay). There's also a Docker image on [Docker Hub](https://hub.docker.com/r/launchdarkly/ld-relay).
 

--- a/src/content/topics/home/advanced/relay-proxy/index.mdx
+++ b/src/content/topics/home/advanced/relay-proxy/index.mdx
@@ -11,7 +11,7 @@ This topic explains what the Relay Proxy is and how to use it.
 
 The Relay Proxy is a small Go application that connects to the LaunchDarkly streaming API and proxies that connection to clients within an organization's network.
 
-The Relay Proxy lets multiple servers connect to a local, private stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
+The Relay Proxy lets multiple servers connect to a local stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
 
 The Relay Proxy is an open-source project supported by LaunchDarkly. The full source is in a [GitHub repository](https://github.com/launchdarkly/ld-relay). There's also a Docker image on [Docker Hub](https://hub.docker.com/r/launchdarkly/ld-relay).
 

--- a/src/content/topics/home/advanced/relay-proxy/index.mdx
+++ b/src/content/topics/home/advanced/relay-proxy/index.mdx
@@ -1,7 +1,7 @@
 ---
 path: '/home/advanced/relay-proxy'
 title: 'The Relay Proxy'
-description: 'This topic explains what the Relay Proxy is and how to use it. The Relay Proxy is an open-source microservice that connects to LaunchDarkly. The Relay Proxy lets servers connect to a local stream instead of making outbound connections to LaunchDarkly''s streaming service.'
+description: 'This topic explains what the Relay Proxy is and how to use it. The Relay Proxy is an open-source application that connects to LaunchDarkly. The Relay Proxy lets servers connect to a local stream instead of making outbound connections to LaunchDarkly''s streaming service.'
 published: true
 ---
 
@@ -9,9 +9,9 @@ published: true
 
 This topic explains what the Relay Proxy is and how to use it.
 
-The Relay Proxy is a microservice that connects to the LaunchDarkly streaming API and proxies that connection to multiple clients.
+The Relay Proxy is a small Go application that connects to the LaunchDarkly streaming API and proxies that connection to clients within an organziation's network.
 
-The Relay Proxy lets a number of servers connect to a local stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
+The Relay Proxy lets private servers connect to a local stream instead of making a large number of outbound connections to LaunchDarkly's streaming service (`stream.launchdarkly.com`). You can configure the Relay Proxy to carry multiple environment streams from multiple projects.
 
 The Relay Proxy is an open-source project supported by LaunchDarkly. The full source is in a [GitHub repository](https://github.com/launchdarkly/ld-relay). There's also a Docker image on [Docker Hub](https://hub.docker.com/r/launchdarkly/ld-relay).
 


### PR DESCRIPTION
This might be a nit, but I don't think we should use the term "microservice" in the context of a single application.  The term "microservices" is, I believe, generally meant to refer to a large scale system architecture in which multiple independently deployable applications are organized around domain bounded contexts.  By this definition it doesn't make much sense to talk about a single application being a microservice. 

I think what we're trying to say here is just that relay proxy is "small".