### PR TITLE
Remove: Callout for Custom Roles and Permissions.

### DIFF
--- a/src/content/topics/home/managing-flags/feature-workflows/approvals.mdx
+++ b/src/content/topics/home/managing-flags/feature-workflows/approvals.mdx
@@ -42,17 +42,6 @@ Anyone with a `writer`, `owner / admin`, or custom role can approve a flag chang
 
 From that email, a requested approver can access a summary page of the flag changes and approve or decline the changes proposed.
 
-<Callout intent="info">
-<CalloutTitle>Use custom roles to refine approval permissions</CalloutTitle>
-<CalloutDescription>
-
-You can configure a custom role policy to allow or deny specific actions on approval requests. For example, you can deny any role from changing a flag in the Production environment without an approval from a team member with the `owner / admin` role.
-
-To learn more about custom roles actions for this feature, read [Using actions](/home/account-security/custom-roles/actions).
-
-</CalloutDescription>
-</Callout>
-
 ## Requesting approval for a flag change
 
 You can request approval on changes to a flag's targeting at any point after creation. 


### PR DESCRIPTION
Removing the Callout Section titled: _Use custom roles to refine approval permissions._

Our custom roles do not support this.