### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -776,7 +776,9 @@ You can record custom events using the `track` function. In LaunchDarkly, you ca
 
 To learn more, read [Experimentation](/home/experimentation).
 
-Call track with the event name to record custom conversion metrics. The second argument is optional.
+Call track with the event name to record custom conversion metrics. 
+
+The second argument is optional and useful for observational analytics with the use of LaunchDarkly's Data Export feature. Lastly, with Data Export, the second argument is used to give additional context without saving the data to the LaunchDarkly user context.
 
 <CodeTabs
   defaultValue="js"

--- a/src/content/topics/sdk/client-side/javascript/index.mdx
+++ b/src/content/topics/sdk/client-side/javascript/index.mdx
@@ -778,7 +778,7 @@ To learn more, read [Experimentation](/home/experimentation).
 
 Call track with the event name to record custom conversion metrics. 
 
-The second argument is optional and useful for observational analytics with the use of LaunchDarkly's Data Export feature. Lastly, with Data Export, the second argument is used to give additional context without saving the data to the LaunchDarkly user context.
+The second argument is optional. It assists with observational analytics for Data Export destinations. With Data Export, the second argument gives additional context without saving the data to the LaunchDarkly user.
 
 <CodeTabs
   defaultValue="js"


### PR DESCRIPTION
The second argument is optional and useful for observational analytics with the use of LaunchDarkly's Data Export feature. Lastly, with Data Export, the second argument is used to give additional context without saving the data to the LaunchDarkly user context.

https://launchdarkly.slack.com/archives/CBHU9PJG5/p1613589187321000