### PR TITLE
Add `updateRuleDescription` action to list of flag actions

### DIFF
--- a/src/content/topics/home/managing-your-team/custom-roles/actions.mdx
+++ b/src/content/topics/home/managing-your-team/custom-roles/actions.mdx
@@ -843,7 +843,7 @@ To learn more, read [Creating a feature flag](/home/getting-started/feature-flag
     </TableRow>
     <TableRow>
       <TableCell>
-        <code>updateRuleDescription</code>
+        <code>updateFlagRuleDescription</code>
       </TableCell>
       <TableCell>Update the description for custom targeting rules.</TableCell>
     </TableRow>

--- a/src/content/topics/home/managing-your-team/custom-roles/actions.mdx
+++ b/src/content/topics/home/managing-your-team/custom-roles/actions.mdx
@@ -843,6 +843,12 @@ To learn more, read [Creating a feature flag](/home/getting-started/feature-flag
     </TableRow>
     <TableRow>
       <TableCell>
+        <code>updateRuleDescription</code>
+      </TableCell>
+      <TableCell>Update the description for custom targeting rules.</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell>
         <code>updateFallthrough</code>
       </TableCell>
       <TableCell>Update the "default" or "fallthrough" rule.</TableCell>


### PR DESCRIPTION
This is currently missing, as noted here: https://app.clubhouse.io/launchdarkly/story/103091/custom-role-setup-does-not-allow-for-user-to-be-able-to-edit-flag-rule-name-description#activity-103167