### PR TITLE
Fix "evaluation reasons" link

### DIFF
--- a/src/content/topics/sdk/concepts/client-side-server-side.mdx
+++ b/src/content/topics/sdk/concepts/client-side-server-side.mdx
@@ -94,7 +94,7 @@ The client- and server-side SDKs have different security considerations.
 
 These SDKs typically run on customers' own devices. They can be compromised by users who unpack a mobile app to examine the SDK bytecode or use their browser's developer tools to inspect internal site data. As a result, you should never use a server-side SDK key in a client-side or mobile application.
 
-Flag rules may include user identifiers or other personally identifiable information (PII) that you might not want to transmit to client-side applications. Consequently, client-side SDKs depend on LaunchDarkly's servers to safely store flag rules. To learn more, read [Evaluation reasons](#evaluation-reasons).
+Flag rules may include user identifiers or other personally identifiable information (PII) that you might not want to transmit to client-side applications. Consequently, client-side SDKs depend on LaunchDarkly's servers to safely store flag rules. To learn more, read [Evaluation reasons](/sdk/concepts/evaluation-reasons).
 
 ### Server-side SDKs
 


### PR DESCRIPTION
Fixes the link under https://docs.launchdarkly.com/sdk/concepts/client-side-server-side#security