### PR TITLE
Update Android Java key config

### DIFF
--- a/src/content/topics/sdk/features/config.mdx
+++ b/src/content/topics/sdk/features/config.mdx
@@ -49,7 +49,7 @@ This code sample shows you how to configure the client connect and flush interva
 
 ```java
 LDConfig ldConfig = new LDConfig.Builder()
-    .setMobileKey("YOUR_MOBILE_KEY")
+    .mobileKey("YOUR_MOBILE_KEY")
     .setConnectionTimeoutMillis(5000)
     .setEventsFlushIntervalMillis(5000)
     .build();


### PR DESCRIPTION
According to this: https://launchdarkly.github.io/android-client-sdk/

The config.builder should use ".mobileKey" not ".setMobileKey"

Thanks!