### PR TITLE
Api Docs

### DIFF
--- a/apidocs/access-tokens.md
+++ b/apidocs/access-tokens.md
@@ -1,8 +1,8 @@
 The access tokens API allows you to list, create, modify, and delete access tokens programmatically. 
 
 When using access tokens to manage access tokens, the following restrictions apply:
-- [Personal tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens) can see all service tokens and other personal tokens created by the same team member. If the personal token has the "Admin" role, it may also see other member's personal tokens.
-- [Service tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens) can see all service tokens. If the token has the "Admin" role, it may also see all personal tokens.
-- Tokens can only manage other tokens (including themselves) if they have "Admin" role or explicit permission via a [custom role](https://docs.launchdarkly.com/home/account-security/custom-roles/actions#personal-access-token-actions).
+- Personal tokens can see all service tokens and other personal tokens created by the same team member. If the personal token has the "Admin" role, it may also see other member's personal tokens. To learn more, read [Personal tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens).
+- Service tokens can see all service tokens. If the token has the "Admin" role, it may also see all personal tokens. To learn more, read  [Service tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens).
+- Tokens can only manage other tokens, including themselves, if they have "Admin" role or explicit permission via a custom role. To learn more, read [Personal access token actions](https://docs.launchdarkly.com/home/team/role-actions#personal-access-token-actions).
 
-[Learn more about access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens).
+To learn more about access tokens,  read [API access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens).

--- a/apidocs/access-tokens.md
+++ b/apidocs/access-tokens.md
@@ -5,4 +5,4 @@ When using access tokens to manage access tokens, the following restrictions app
 - Service tokens can see all service tokens. If the token has the "Admin" role, it may also see all personal tokens. To learn more, read  [Service tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens).
 - Tokens can only manage other tokens, including themselves, if they have "Admin" role or explicit permission via a custom role. To learn more, read [Personal access token actions](https://docs.launchdarkly.com/home/team/role-actions#personal-access-token-actions).
 
-To learn more about access tokens,  read [API access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens).
+To learn more about access tokens, read [API access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens).

--- a/apidocs/access-tokens.md
+++ b/apidocs/access-tokens.md
@@ -1,0 +1,8 @@
+The access tokens API allows you to list, create, modify, and delete access tokens programmatically. 
+
+When using access tokens to manage access tokens, the following restrictions apply:
+- [Personal tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#personal-tokens) can see all service tokens and other personal tokens created by the same team member. If the personal token has the "Admin" role, it may also see other member's personal tokens.
+- [Service tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens#service-tokens) can see all service tokens. If the token has the "Admin" role, it may also see all personal tokens.
+- Tokens can only manage other tokens (including themselves) if they have "Admin" role or explicit permission via a [custom role](https://docs.launchdarkly.com/home/account-security/custom-roles/actions#personal-access-token-actions).
+
+[Learn more about access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens).

--- a/apidocs/approvals.md
+++ b/apidocs/approvals.md
@@ -1,3 +1,3 @@
 You may create an approval request for updating a flag and request approval from a team member before applying the changes. You may to select up to ten reviewers to be notified via email, however, anyone with the sufficient permissions can review a pending approval request. At least one approval is needed to allow the changes to be applied.
 
-*Note: Change instructions that are in a conflict state will fail if approved and applied, and the flag will not be updated.*
+Change instructions that are in a conflict state will fail if approved and applied, and the flag will not be updated.

--- a/apidocs/approvals.md
+++ b/apidocs/approvals.md
@@ -1,0 +1,3 @@
+You may create an approval request for updating a flag and request approval from a team member before applying the changes. You may to select up to 10 reviewers to be notified via email, however, anyone with the sufficient permissions can review a pending approval request. At least one approval is needed to allow the changes to be applied.
+
+*Note: Change instructions that are in a conflict state will fail if approved and applied, and the flag will not be updated.*

--- a/apidocs/approvals.md
+++ b/apidocs/approvals.md
@@ -1,3 +1,3 @@
-You may create an approval request for updating a flag and request approval from a team member before applying the changes. You may to select up to 10 reviewers to be notified via email, however, anyone with the sufficient permissions can review a pending approval request. At least one approval is needed to allow the changes to be applied.
+You may create an approval request for updating a flag and request approval from a team member before applying the changes. You may to select up to ten reviewers to be notified via email, however, anyone with the sufficient permissions can review a pending approval request. At least one approval is needed to allow the changes to be applied.
 
 *Note: Change instructions that are in a conflict state will fail if approved and applied, and the flag will not be updated.*

--- a/apidocs/audit-log.md
+++ b/apidocs/audit-log.md
@@ -1,0 +1,1 @@
+The audit log contains a record of all the changes made to any resource in the system. You can filter the audit log by timestamps, or use a custom policy to select which entries to receive.

--- a/apidocs/code-references.md
+++ b/apidocs/code-references.md
@@ -3,4 +3,4 @@
     <p>LaunchDarkly provides the [`ld-find-code-refs` utility](https://github.com/launchdarkly/ld-find-code-refs) that creates repository connections, generates code reference data, and creates calls to the code references API. Most customers should not need to call this API directly.</p>
 </blockquote>
 
-The [code references](https://docs.launchdarkly.com/v2.0/docs/git-code-references) API provides access to all resources related to connected repository, and associated feature flag code reference data for all branches.
+The [code references](https://docs.launchdarkly.com/home/code/code-references) API provides access to all resources related to connected repository, and associated feature flag code reference data for all branches.

--- a/apidocs/code-references.md
+++ b/apidocs/code-references.md
@@ -1,6 +1,6 @@
 <blockquote>
     <h3><span>🚧</span>Use ld-find-code-refs</h3>
-    <p>LaunchDarkly provides the [`ld-find-code-refs` utility](https://github.com/launchdarkly/ld-find-code-refs) that creates repository connections, generates code reference data, and creates calls to the code references API. Most customers should not need to call this API directly.</p>
+    <p>LaunchDarkly provides the [`ld-find-code-refs` utility](https://github.com/launchdarkly/ld-find-code-refs) that creates repository connections, generates code reference data, and creates calls to the code references API. Most customers do not need to call this API directly.</p>
 </blockquote>
 
 The [code references](https://docs.launchdarkly.com/home/code/code-references) API provides access to all resources related to connected repository, and associated feature flag code reference data for all branches.

--- a/apidocs/code-references.md
+++ b/apidocs/code-references.md
@@ -1,0 +1,6 @@
+<blockquote>
+    <h3><span>🚧</span>Use ld-find-code-refs</h3>
+    <p>LaunchDarkly provides the [`ld-find-code-refs` utility](https://github.com/launchdarkly/ld-find-code-refs) that creates repository connections, generates code reference data, and creates calls to the code references API. Most customers should not need to call this API directly.</p>
+</blockquote>
+
+The [code references](https://docs.launchdarkly.com/v2.0/docs/git-code-references) API provides access to all resources related to connected repository, and associated feature flag code reference data for all branches.

--- a/apidocs/custom-roles.md
+++ b/apidocs/custom-roles.md
@@ -1,10 +1,10 @@
 <blockquote>
-    <h3><span>📘</span>Available to enterprise customers</h3>
-    <p>Custom roles are available to customers on our enterprise plans. If you're interested in learning more about our enterprise plans, contact sales@launchdarkly.com.</p>
+    <h3><span>📘</span>Custom roles is an Enterprise feature</h3>
+    <p>Custom roles is available to customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).</p>
 </blockquote>
 
-Custom roles allow you to create flexible policies providing fine-grained access control to everything in LaunchDarkly-- from feature flags to goals, environments and teams. With custom roles, it's possible to enforce access policies that meet your exact workflow needs. 
+Custom roles allow you to create flexible policies providing fine-grained access control to everything in LaunchDarkly, from feature flags to goals, environments and teams. With custom roles, it's possible to enforce access policies that meet your exact workflow needs. 
 
 The custom roles API allows you to create, update and delete custom roles. You can also use the API to list all of your custom roles or get a custom role by ID.
 
-For more information about custom roles and the syntax for custom role policies, see the product documentation for  [Custom roles](https://docs.launchdarkly.com/docs/custom-roles).
+For more information about custom roles and the syntax for custom role policies, read the product documentation for [Custom roles](https://docs.launchdarkly.com/docs/custom-roles).

--- a/apidocs/custom-roles.md
+++ b/apidocs/custom-roles.md
@@ -1,0 +1,10 @@
+<blockquote>
+    <h3><span>📘</span>Available to enterprise customers</h3>
+    <p>Custom roles are available to customers on our enterprise plans. If you're interested in learning more about our enterprise plans, contact sales@launchdarkly.com.</p>
+</blockquote>
+
+Custom roles allow you to create flexible policies providing fine-grained access control to everything in LaunchDarkly-- from feature flags to goals, environments and teams. With custom roles, it's possible to enforce access policies that meet your exact workflow needs. 
+
+The custom roles API allows you to create, update and delete custom roles. You can also use the API to list all of your custom roles or get a custom role by ID.
+
+For more information about custom roles and the syntax for custom role policies, see the product documentation for  [Custom roles](https://docs.launchdarkly.com/docs/custom-roles).

--- a/apidocs/data-export-destinations.md
+++ b/apidocs/data-export-destinations.md
@@ -1,10 +1,10 @@
 <blockquote>
-    <h3><span>📘</span>Available to enterprise customers</h3>
-    <p>Data Export is only available to customers on our enterprise plans. If you're interested in learning more about our enterprise plans, contact [sales@launchdarkly.com](mailto:sales@launchdarkly.com?Subject=Data%20Export).</p>
+    <h3><span>📘</span>Data Export is an add-on feature</h3>
+    <p>Data Export is available as an add-on for customers on an Enterprise plan.  To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).</p>
 </blockquote>
 
 Data Export provides a real-time export of raw analytics data, including feature flag requests, analytics events, custom events, and more. 
 
 _Data Export Destinations_ are locations that receive exported data. The Data Export Destinations API allows you to configure destinations so that your data can be exported.
 
-To learn more about data export, read [Data Export Documentation](https://docs.launchdarkly.com/docs/data-export).
+To learn more, read [Data Export](https://docs.launchdarkly.com/docs/data-export).

--- a/apidocs/data-export-destinations.md
+++ b/apidocs/data-export-destinations.md
@@ -1,0 +1,10 @@
+<blockquote>
+    <h3><span>📘</span>Available to enterprise customers</h3>
+    <p>Data Export is only available to customers on our enterprise plans. If you're interested in learning more about our enterprise plans, contact [sales@launchdarkly.com](mailto:sales@launchdarkly.com?Subject=Data%20Export).</p>
+</blockquote>
+
+Data Export provides a real-time export of raw analytics data, including feature flag requests, analytics events, custom events, and more. 
+
+_Data Export Destinations_ are locations that receive exported data. The Data Export Destinations API allows you to configure destinations so that your data can be exported.
+
+To learn more about data export, read [Data Export Documentation](https://docs.launchdarkly.com/docs/data-export).

--- a/apidocs/data-export-destinations.md
+++ b/apidocs/data-export-destinations.md
@@ -1,6 +1,6 @@
 <blockquote>
     <h3><span>📘</span>Data Export is an add-on feature</h3>
-    <p>Data Export is available as an add-on for customers on an Enterprise plan.  To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).</p>
+    <p>Data Export is available as an add-on for customers on an Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).</p>
 </blockquote>
 
 Data Export provides a real-time export of raw analytics data, including feature flag requests, analytics events, custom events, and more. 

--- a/apidocs/environments.md
+++ b/apidocs/environments.md
@@ -1,1 +1,1 @@
-Environments allow you to maintain separate rollout rules in different contexts--  from local development to QA, staging, and production. With the LaunchDarkly Environments API, you can programmatically create, delete, and update environments.
+Environments allow you to maintain separate rollout rules in different contexts,  from local development to QA, staging, and production. With the LaunchDarkly Environments API, you can programmatically create, delete, and update environments.

--- a/apidocs/environments.md
+++ b/apidocs/environments.md
@@ -1,0 +1,1 @@
+Environments allow you to maintain separate rollout rules in different contexts--  from local development to QA, staging, and production. With the LaunchDarkly Environments API, you can programmatically create, delete, and update environments.

--- a/apidocs/environments.md
+++ b/apidocs/environments.md
@@ -1,1 +1,1 @@
-Environments allow you to maintain separate rollout rules in different contexts,  from local development to QA, staging, and production. With the LaunchDarkly Environments API, you can programmatically create, delete, and update environments.
+Environments allow you to maintain separate rollout rules in different contexts, from local development to QA, staging, and production. With the LaunchDarkly Environments API, you can programmatically create, delete, and update environments.

--- a/apidocs/experiments.md
+++ b/apidocs/experiments.md
@@ -1,3 +1,3 @@
-An experiment is a running tally of user behaviors based on which variation of a feature flag they receive. In LaunchDarkly, an experiment requires two things: a metric that defines what user behavior(s) to track, and at least one flag associated with that metric.
+An experiment is a running tally of user behaviors based on which variation of a feature flag they receive. In LaunchDarkly, an experiment requires two things: a metric that defines what user behaviors to track, and at least one flag associated with that metric.
 
-Experiments are largely managed via PATCH requests to the Flags API.  There are also dedicated API resources for getting and deleting experiment data.
+Experiments are largely managed via PATCH requests to the Flags API. There are also dedicated API resources for getting and deleting experiment data.

--- a/apidocs/experiments.md
+++ b/apidocs/experiments.md
@@ -1,0 +1,3 @@
+An experiment is a running tally of user behaviors based on which variation of a feature flag they receive. In LaunchDarkly, an experiment requires two things: a metric that defines what user behavior(s) to track, and at least one flag associated with that metric.
+
+Experiments are largely managed via PATCH requests to the Flags API.  There are also dedicated API resources for getting and deleting experiment data.

--- a/apidocs/feature-flags.md
+++ b/apidocs/feature-flags.md
@@ -1,12 +1,12 @@
 ## Anatomy of a feature flag
 
-The feature flag API allows you to control percentage rollouts, target specific users, or even hit the 'kill' switch for a feature programmatically. By looking at the representation of a feature flag, we can see how to do any of these tasks.
+The feature flag API allows you to control percentage rollouts, target specific users, or even toggle off a feature programmatically. By looking at the representation of a feature flag, we can see how to do any of these tasks.
 
 ## Sample feature flag representation
 
 Every feature flag has a set of top-level attributes, as well as an `environments` map containing the flag rollout and targeting rules specific to each environment. Top-level attributes include things like the flag's name, description, tags, and creation date.
 
-For reference, here's a complete feature flag representation. We'll be breaking this down and explaining each attribute in detail.
+For reference, here's a complete feature flag representation. We will break this down and explain each attribute in detail.
 
 ```json
 {
@@ -166,7 +166,7 @@ For reference, here's a complete feature flag representation. We'll be breaking 
 
 ## Top-level attributes
 
-Most of the top-level attributes have a straightforward interpretation. For example, to change the name of a feature, simply [update the feature flag](doc:update-feature-flag) with the `name` attribute set to the new name:
+Most of the top-level attributes have a straightforward interpretation. For example, to change the name of a feature, [update the feature flag](doc:update-feature-flag) with the `name` attribute set to the new name:
 
 ```json
 [
@@ -174,11 +174,11 @@ Most of the top-level attributes have a straightforward interpretation. For exam
 ]
 ```
 
-The `variations` array is worth calling out. This array represents the different variation values that a feature flag has. For a boolean flag, there are two variations-- `true` and `false`. Multivariate flags will have more variation values, and those values could be any JSON type (numbers, strings, objects, or arrays). In targeting rules, the variations are referred to by their index into this array. This will be clearer below when we look at some specific examples.
+The `variations` array represents the different variation values that a feature flag has. For a boolean flag, there are two variations: `true` and `false`. Multivariate flags have more variation values, and those values could be any JSON type: numbers, strings, objects, or arrays. In targeting rules, the variations are referred to by their index into this array. Below are some specific examples.
 
 ## Per-environment configurations
 
-Each entry in the `environments` map contains a JSON object that represents the environment-specific flag configuration data that you see on the [Targeting](http://docs.launchdarkly.com/v2.0/docs/targeting-users) tab of your Manage Feature page. For example, to toggle the kill switch for a feature flag in your production environment, use the following JSON patch operation:
+Each entry in the `environments` map contains a JSON object that represents the environment-specific flag configuration data that you see on the [Targeting](https://docs.launchdarkly.com/home/flags/targeting-users) tab of your Manage Feature page. For example, to toggle off a feature flag in your production environment, use the following JSON patch operation:
 
 ```json
 [
@@ -209,20 +209,20 @@ The `targets` array in the per-environment configuration data represents the ind
 }
 ```
 
-This `targets` array here means that user `foo@example.com` should receive the first variation listed in the `variations` array (recall that the variations are stored at the top level of the flag JSON in an array, and the per-environment configuration rules point to indexes into this array). If this is a boolean flag, that means that `foo@example.com` is receiving the `true` variation.
+This `targets` array here means that user `foo@example.com` receives the first variation listed in the `variations` array. Recall that the variations are stored at the top level of the flag JSON in an array, and the per-environment configuration rules point to indexes into this array. If this is a boolean flag, `foo@example.com` is receiving the `true` variation.
 
 ## Targeting rules
 
-The `rules` array corresponds to the custom targeting rules section of the Targeting tab. This is where you can express complex rules on attributes with conditions and operators. For example, a rule like "roll the `true` variation out to 80% of users whose e-mail address ends with `gmail.com` would be expressed here.
+The `rules` array corresponds to the custom targeting rules section of the Targeting tab. This is where you can express complex rules on attributes with conditions and operators. For example, a rule like "roll out the `true` variation to 80% of users whose email address ends with `gmail.com` could be expressed here.
 
 ## The fallthrough rule
 
-The `fallthrough` object is a special rule that contains no conditions-- it is the rollout strategy that is applied when none of the individual or custom targeting rules match.
+The `fallthrough` object is a special rule that contains no conditions. It is the rollout strategy that is applied when none of the individual or custom targeting rules match.
 
 ## The off variation
 
-The off variation represents the variation to serve if the feature flag is killed (the `on` attribute is `false`). For boolean flags, this is usually `false`. For multivariate flags, set the off variation to whatever variation represents the control or baseline behavior for your application. If you don't set the off variation, LaunchDarkly will serve the fallback value defined in your code.
+The off variation represents the variation to serve if the feature flag is turned off, meaning the `on` attribute is `false`. For boolean flags, this is usually `false`. For multivariate flags, set the off variation to whatever variation represents the control or baseline behavior for your application. If you don't set the off variation, LaunchDarkly will serve the fallback value defined in your code.
 
 ## Percentage rollouts
 
-The `weight` attribute defines the percentage rollout for each variation. Weights range from 0 (0% rollout) to 100000 (a 100% rollout). The weights are scaled by a factor of 1000 so that fractions of a percent can be represented without using floating point-- so a weight of `50000` means that 50% of users (that don't otherwise match any `targets`, see above) will see that variation. The sum of weights across all variations should be 100%.
+The `weight` attribute defines the percentage rollout for each variation. Weights range from 0 (a 0% rollout) to 100000 (a 100% rollout). The weights are scaled by a factor of 1000 so that fractions of a percent can be represented without using floating-point. For example, a weight of `50000` means that 50% of users that don't otherwise match any `targets` will see that variation. The sum of weights across all variations should be 100%.

--- a/apidocs/feature-flags.md
+++ b/apidocs/feature-flags.md
@@ -166,7 +166,7 @@ For reference, here's a complete feature flag representation. We will break this
 
 ## Top-level attributes
 
-Most of the top-level attributes have a straightforward interpretation. For example, to change the name of a feature, [update the feature flag](doc:update-feature-flag) with the `name` attribute set to the new name:
+Most of the top-level attributes have a straightforward interpretation. For example, to change the name of a feature, [update the feature flag](#operation/patchFeatureFlag) with the `name` attribute set to the new name:
 
 ```json
 [

--- a/apidocs/feature-flags.md
+++ b/apidocs/feature-flags.md
@@ -6,7 +6,7 @@ The feature flag API allows you to control percentage rollouts, target specific 
 
 Every feature flag has a set of top-level attributes, as well as an `environments` map containing the flag rollout and targeting rules specific to each environment. Top-level attributes include things like the flag's name, description, tags, and creation date.
 
-For reference, here's a complete feature flag representation. We will break this down and explain each attribute in detail.
+For reference, here's a complete feature flag representation. Below we break this down and explain each attribute in detail.
 
 ```json
 {

--- a/apidocs/feature-flags.md
+++ b/apidocs/feature-flags.md
@@ -1,0 +1,228 @@
+## Anatomy of a feature flag
+
+The feature flag API allows you to control percentage rollouts, target specific users, or even hit the 'kill' switch for a feature programmatically. By looking at the representation of a feature flag, we can see how to do any of these tasks.
+
+## Sample feature flag representation
+
+Every feature flag has a set of top-level attributes, as well as an `environments` map containing the flag rollout and targeting rules specific to each environment. Top-level attributes include things like the flag's name, description, tags, and creation date.
+
+For reference, here's a complete feature flag representation. We'll be breaking this down and explaining each attribute in detail.
+
+```json
+{
+  "name": "Alternate product page",
+  "kind": "boolean",
+  "description": "This is a description",
+  "key": "alternate.page",
+  "creationDate": 1418684722483,
+  "includeInSnippet": true,
+  "variations": [
+    {
+      "value": true,
+      "name": "true"
+    },
+    {
+      "value": false,
+      "name": "false"
+    }
+  ],
+  "defaults": {
+    "onVariation": 0,
+    "offVariation": 1
+  },
+  "temporary": false,
+  "tags": ["ops", "experiments"],
+  "_links": {
+    "parent": {
+      "href": "/api/v2/flags/default",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/flags/default/alternate.page",
+      "type": "application/json"
+    }
+  },
+  "maintainerId": "548f6741c1efad40031b18ae",
+  "_maintainer": {
+    "_links": {
+      "parent": {
+        "href": "/internal/account/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/members/548f6741c1efad40031b18ae",
+        "type": "application/json"
+      }
+    },
+    "_id": "548f6741c1efad40031b18ae",
+    "firstName": "Reese",
+    "lastName": "App",
+    "role": "owner",
+    "email": "refapp@launchdarkly.com",
+    "_pendingInvite": false,
+    "isBeta": false,
+    "customRoles": []
+  },
+  "goalIds": [],
+  "environments": {
+    "production": {
+      "on": true,
+      "archived": false,
+      "salt": "YWx0ZXJuYXRlLnBhZ2U=",
+      "sel": "45501b9314dc4641841af774cb038b96",
+      "lastModified": 1469326565348,
+      "version": 61,
+      "targets": [
+        {
+          "values": ["1461797806427-7-115540266"],
+          "variation": 0
+        },
+        {
+          "values": ["Gerhard.Little@yahoo.com"],
+          "variation": 1
+        }
+      ],
+      "rules": [
+        {
+          "variation": 0,
+          "clauses": [
+            {
+              "attribute": "groups",
+              "op": "in",
+              "values": ["Top Customers"],
+              "negate": false
+            },
+            {
+              "attribute": "email",
+              "op": "endsWith",
+              "values": ["gmail.com"],
+              "negate": false
+            }
+          ]
+        }
+      ],
+      "fallthrough": {
+        "rollout": {
+          "variations": [
+            {
+              "variation": 0,
+              "weight": 60000
+            },
+            {
+              "variation": 1,
+              "weight": 40000
+            }
+          ]
+        }
+      },
+      "offVariation": 1,
+      "prerequisites": [],
+      "_site": {
+        "href": "/default/production/features/alternate.page",
+        "type": "text/html"
+      }
+    },
+    "test": {
+      "on": true,
+      "archived": false,
+      "salt": "YWx0ZXJuYXRlLnBhZ2U=",
+      "sel": "76c63094d35949bb9dc9bd5c570bacf5",
+      "lastModified": 1455145480896,
+      "version": 37,
+      "targets": [
+        {
+          "values": [],
+          "variation": 0
+        },
+        {
+          "values": [],
+          "variation": 1
+        }
+      ],
+      "rules": [],
+      "fallthrough": {
+        "rollout": {
+          "variations": [
+            {
+              "variation": 0,
+              "weight": 49000
+            },
+            {
+              "variation": 1,
+              "weight": 51000
+            }
+          ]
+        }
+      },
+      "prerequisites": [],
+      "_site": {
+        "href": "/default/tester/features/alternate.page",
+        "type": "text/html"
+      }
+    }
+  }
+}
+```
+
+## Top-level attributes
+
+Most of the top-level attributes have a straightforward interpretation. For example, to change the name of a feature, simply [update the feature flag](doc:update-feature-flag) with the `name` attribute set to the new name:
+
+```json
+[
+    { "op": "replace", "path": "/name", "value": "New name" }
+]
+```
+
+The `variations` array is worth calling out. This array represents the different variation values that a feature flag has. For a boolean flag, there are two variations-- `true` and `false`. Multivariate flags will have more variation values, and those values could be any JSON type (numbers, strings, objects, or arrays). In targeting rules, the variations are referred to by their index into this array. This will be clearer below when we look at some specific examples.
+
+## Per-environment configurations
+
+Each entry in the `environments` map contains a JSON object that represents the environment-specific flag configuration data that you see on the [Targeting](http://docs.launchdarkly.com/v2.0/docs/targeting-users) tab of your Manage Feature page. For example, to toggle the kill switch for a feature flag in your production environment, use the following JSON patch operation:
+
+```json
+[
+    { "op": "replace", "path": "/environments/production/on", "value": false }
+]
+```
+
+Each section of the Targeting tab corresponds to a different attribute of the per-environment configuration data, as shown here:
+
+## Individual user targets
+
+The `targets` array in the per-environment configuration data represents the individual user targeting rules on the Targeting tab. Each object in the `targets` array represents a list of user keys assigned to a particular variation. For example:
+
+```json
+{
+    ...
+    "environments" : {
+        "production" : {
+            ...
+            "targets": [
+                {
+                    "values": ["foo@example.com"],
+                    "variation: 0
+                }
+            ]
+        }
+    }
+}
+```
+
+This `targets` array here means that user `foo@example.com` should receive the first variation listed in the `variations` array (recall that the variations are stored at the top level of the flag JSON in an array, and the per-environment configuration rules point to indexes into this array). If this is a boolean flag, that means that `foo@example.com` is receiving the `true` variation.
+
+## Targeting rules
+
+The `rules` array corresponds to the custom targeting rules section of the Targeting tab. This is where you can express complex rules on attributes with conditions and operators. For example, a rule like "roll the `true` variation out to 80% of users whose e-mail address ends with `gmail.com` would be expressed here.
+
+## The fallthrough rule
+
+The `fallthrough` object is a special rule that contains no conditions-- it is the rollout strategy that is applied when none of the individual or custom targeting rules match.
+
+## The off variation
+
+The off variation represents the variation to serve if the feature flag is killed (the `on` attribute is `false`). For boolean flags, this is usually `false`. For multivariate flags, set the off variation to whatever variation represents the control or baseline behavior for your application. If you don't set the off variation, LaunchDarkly will serve the fallback value defined in your code.
+
+## Percentage rollouts
+
+The `weight` attribute defines the percentage rollout for each variation. Weights range from 0 (0% rollout) to 100000 (a 100% rollout). The weights are scaled by a factor of 1000 so that fractions of a percent can be represented without using floating point-- so a weight of `50000` means that 50% of users (that don't otherwise match any `targets`, see above) will see that variation. The sum of weights across all variations should be 100%.

--- a/apidocs/metrics.md
+++ b/apidocs/metrics.md
@@ -1,0 +1,8 @@
+<blockquote>
+    <h3><span>📘</span>This feature is currently in beta</h3>
+    <p>To use this feature, pass in a header including the `LD-API-Version` key with value set to `beta`. Use this header with each call.</p>
+</blockquote>
+
+Metrics track flag behavior over time when an experiment is running. The data generated from experiments gives you more insight into the impact of a particular flag.
+
+Using the Metrics API, you can create, delete, and manage metrics.

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -364,7 +364,9 @@ This specification is generated from the [ld-openapi repository on GitHub](https
 
 You can use this specification to generate client libraries to interact with our REST API in your language of choice. 
 
-Our client libraries, in addition to community-supported clients, are available on [GitHub](https://github.com/topics/launchdarkly-api).
+# Client libraries
+
+Our client libraries, in addition to community-supported clients, are available on [GitHub](https://github.com/search?q=topic%3Alaunchdarkly-api+org%3Alaunchdarkly&type=Repositories).
 
 # Method Overriding
 

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -281,28 +281,156 @@ You can change the feature flag's description with the following patch document 
 
 # Errors
 
-TODO
+The API always returns errors in a common format. Here's an example:
+
+```json
+{
+    "code": "invalid_request",
+    "message": "A feature with that key already exists",
+    "id": "30ce6058-87da-11e4-b116-123b93f75cba"
+}
+```
+
+The general class of error is indicated by the `code`. The `message` is a human-readable explanation of what went wrong. The `id` is a unique identifier-- use it when you're working with LaunchDarkly support to debug a problem with a specific API call.
+
+## HTTP Status - Error Response Codes
+
+| Code | Definition | Desc. | Possible Solution |
+| ---- | ---------- | ----- | ----------------- |
+| 400  | Bad Request | A request that fails may return this HTTP response code | Ensure JSON syntax in request body is correct. |
+| 401  | Unauthorized | User doesn't have permission to an API call | Ensure your SDK key is good. |
+| 403  | Forbidden | User does not have permission for operation. | Ensure that the user or access token has proper permissions set. |
+| 409  | Conflict | The API request could not be completed because it conflicted with a concurrent API request. | Retry your request. |
+| 429  | Too many requests | See [Rate limiting](ref:rate-limiting) | Wait and try again later. |
 
 # CORS
 
-TODO
+The LaunchDarkly API supports Cross Origin Resource Sharing (CORS) for AJAX requests from any origin.  If an `Origin` header is given in a request, it will be echoed as an explicitly allowed origin. Otherwise, a wildcard will be returned: `Access-Control-Allow-Origin: *`.  For more information on CORS, see the [CORS W3C Recommendation](http://www.w3.org/TR/cors).  Example CORS headers might look like:
+
+```http
+Access-Control-Allow-Headers: Accept, Content-Type, Content-Length, Accept-Encoding, Authorization
+Access-Control-Allow-Methods: OPTIONS, GET, DELETE, PATCH
+Access-Control-Allow-Origin: *
+Access-Control-Max-Age: 300
+```
+
+You can make authenticated CORS calls just as you would make same-origin calls, using either [token or session-based authentication](doc:authentication). If you’re using session auth, you should set the `withCredentials` property for your `xhr` request to `true`. Remember-- you should never expose your access tokens to untrusted users.
 
 # Rate limiting
 
-TODO
+We use several rate limiting strategies to ensure the availability of our APIs. Rate-limited calls to our APIs will return a `429` status code. Calls to our APIs will include headers indicating the current rate limit status. The specific headers returned depend on the API route being called-- the limits differ based on the route, authentication mechanism, and other factors. Routes that are not rate limited may not contain any of the headers described below.
+
+<blockquote>
+    <h3><span>❗️</span>Rate limiting and SDKs</h3>
+    <p>Our SDKs are never rate limited. Our SDKs do not use the API endpoints defined here-- we use a different set of approaches (streaming / server-sent events as well as a global CDN) to ensure availability to the routes used by our SDKs.</p>
+    <p>The client-side ID is safe to embed in untrusted contexts-- it's designed for use in client-side JavaScript.</p>
+</blockquote>
+
+## Global rate limits
+
+Authenticated requests are subject to a global limit-- this is the maximum number of calls that can be made to the API per ten seconds. All personal access tokens on the account share this limit, so exceeding the limit with one access token will impact other tokens. Calls that are subject to global rate limits will return the headers below:
+
+| Header name | Description |
+| ----------- | ----------- |
+| `X-Ratelimit-Global-Remaining` | The maximum number of requests the account is permitted to make per ten seconds. |
+| `X-Ratelimit-Reset` | The time at which the current rate limit window resets in epoch milliseconds. |
+
+We do not publicly document the specific number of calls that can be made globally. This limit may change, and we encourage clients to program against the specification (relying on the two headers defined above) rather than hardcoding to the current limit.
+
+## Route-level rate limits
+
+Some authenticated routes have custom rate limits. These also reset every ten seconds. Any access tokens hitting the same route share this limit, so exceeding the limit with one access token may impact other tokens. Calls that are subject to route-level rate limits will return the headers below:
+
+| Header name | Description |
+| ----------- | ----------- |
+| `X-Ratelimit-Route-Remaining` | The maximum number of requests to the current route the account is permitted to make per ten seconds. |
+| `X-Ratelimit-Reset` | The time at which the current rate limit window resets in epoch milliseconds. |
+
+A *route* represents a specific URL pattern and verb. For example, the [Delete environment](doc:delete-environment) endpoint is considered a single route, and each call to delete an environment counts against your route-level rate limit for that route. 
+
+We do not publicly document the specific number of calls that can be made to each endpoint per ten seconds. These limits may change, and we encourage clients to program against the specification (relying on the two headers defined above) rather than hardcoding to the current limits.
+
+## IP-based rate limiting
+
+We also employ IP-based rate limiting on some API routes. If you hit an IP-based rate limit, your API response will include a `Retry-After` header indicating how long to wait before re-trying the call. Clients must wait at least `Retry-After` seconds before making additional calls to our API, and should employ jitter and backoff strategies to avoid triggering rate limits again.
 
 # Open API (Swagger)
 
-TODO
+We have a complete Open API (Swagger) specification for our API hosted here:
+
+[LaunchDarkly OpenAPI specification](https://launchdarkly.github.io/ld-openapi/openapi.yaml)
+
+This specification is generated from the [ld-openapi repository on GitHub](https://github.com/launchdarkly/ld-openapi). 
+
+You can use this specification to generate client libraries to interact with our REST API in your language of choice. 
+
+Our client libraries, in addition to community-supported clients, are available on [GitHub](https://github.com/topics/launchdarkly-api).
 
 # Method Overriding
 
-TODO
+Some firewalls and HTTP clients restrict the use of verbs other than `GET` and `POST`. In those environments, our API endpoints that use `PUT`, `PATCH`, and `DELETE` verbs will be inaccessible.
+
+To avoid this issue, our API supports the `X-HTTP-Method-Override` header, allowing clients to "tunnel" `PUT`, `PATCH`, and `DELETE` requests via a `POST` request. 
+
+For example, if you wish to call one of our `PATCH` resources via a `POST` request, you can include `X-HTTP-Method-Override:PATCH` as a header.
 
 # Beta resources
 
-TODO
+We sometimes release new API resources in **beta** status before we release them with general availability. 
+
+Resources that are in beta are still undergoing testing and development. They may change without notice, including becoming backwards incompatible. 
+
+We try to promote resources into general availability as quickly as possible. This happens after sufficient testing and when we're satisfied that we no longer need to make backwards-incompatible changes.
+
+We mark beta resources with a "Beta" callout in our documentation, pictured below:
+<blockquote>
+    <h3><span>📘</span>Beta</h3>
+    <p>**This feature is in beta.** You must include a specific header to use it.\n\nTo learn more, read [Beta resources](ref:beta-resources).</p>
+</blockquote>
+
+## Using beta resources
+
+To use a beta resource, you must include a header in the request. If you call a beta resource without this header, you'll receive a `403` response.
+
+Use this header: 
+
+```
+LD-API-Version: beta
+```
 
 # Versioning
 
-TODO
+We try hard to keep our REST API backwards compatible, but we occasionally have to make backwards-incompatible changes in the process of shipping new features. These breaking changes can cause unexpected behavior if you don't prepare for them accordingly. 
+
+Updates to our REST API include support for the latest features in LaunchDarkly. We also release a new version of our REST API every time we make a breaking change. We provide simultaneous support for multiple API versions so you can migrate from your current API version to a new version at your own pace. 
+
+See new versions in the [Changelog](ref:changelog).
+
+## Setting the API version per request
+
+You can set the API version on a specific request by sending an `LD-API-Version` header, as shown in the example below
+
+```
+LD-API-Version: 20191212
+```
+
+The header value is the version number of the API version you'd like to request. The number for each version corresponds to the date the version was released; in the example above the version `20191212` corresponds to December 12, 2019. 
+
+## Setting the API version per access token
+
+When creating an access token, you must specify a specific version of the API to use. This ensures that integrations using this token cannot be broken by version changes.
+
+Tokens created before versioning was released have their version set to `20160426` (the version of the API that existed before versioning) so that they continue working the same way they did before versioning.
+
+If you would like to upgrade your integration to use a new API version, you can explicitly set the header described above.
+
+<blockquote>
+    <h3><span>👍</span>Best practice: Set the header for every client or integration</h3>
+    <p>We recommend that you set the API version header explicitly in any client or integration you build.</p>
+    <p>Only rely on the access token API version during manual testing.</p>
+</blockquote>
+
+<blockquote>
+    <h3><span>🚧</span>API Path Versioning</h3>
+    <p>In the past, we've used path-based API versioning (e.g. versioning resources by adding `v2` to endpoint URLs). We don't foresee the need to do this again, but reserve the right to do so if we find the need to make major revisions to the API.</p>
+</blockquote>

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -1,0 +1,308 @@
+# Authentication
+
+All REST API resources are authenticated with [personal access tokens](https://docs.launchdarkly.com/v2.0/docs/api-access-tokens) or session cookies. Other authentication mechanisms are not supported. You can manage personal access tokens on your [Account settings](https://app.launchdarkly.com/settings/tokens) page. 
+
+LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used by our server-side SDKs,  mobile SDKs, and client-side JavaScript SDKs, respectively. **These keys cannot be used to access our REST API**. These keys are environment-specific, and can only perform read-only operations (fetching feature flag settings).
+
+| Auth mechanism | Allowed resources | Use cases |
+| -------------- | ----------------- | --------- |
+| [Personal access tokens](https://docs.launchdarkly.com/v2.0/docs/api-access-tokens) | Can be customized on a per-token basis | Building scripts, custom integrations, data export |
+| SDK keys | Can only access read-only SDK-specific resources and the firehose, restricted to a single environment | Server-side SDKs, Firehose API |
+| Mobile keys | Can only access read-only mobile SDK-specific resources, restricted to a single environment | Mobile SDKs |
+| Client-side ID | Single environment, only flags marked available to client-side | Client-side JavaScript |
+
+<blockquote>
+    <h3><span>❗️</span>Keep your access tokens and SDK keys private</h3>
+    <p>Access tokens should *never* be exposed in untrusted contexts. Never put an access token in client-side JavaScript, or embed it in a mobile application (LaunchDarkly has special mobile keys that you can embed in mobile apps). If you accidentally expose an access token or SDK key, you can reset it from your [Account Settings](https://app.launchdarkly.com/settings#/tokens) page.</p>
+    <p>The client-side ID is safe to embed in untrusted contexts-- it's designed for use in client-side JavaScript.</p>
+</blockquote>
+
+## Via request header
+
+The preferred way to authenticate with the API is by adding an `Authorization` header containing your access token to your requests. The value of the `Authorization` header must be your access token.
+
+Manage personal access tokens from the [Account Settings](https://app.launchdarkly.com/settings/tokens) page.
+
+## Via session cookie
+
+For testing purposes, you can make API calls directly from your web browser. If you're logged in to the application, the API will use your existing session to authenticate calls.
+
+If you have a [role](http://docs.launchdarkly.com/v2.0/docs/teams) other than Admin, or have a [custom role](http://docs.launchdarkly.com/v2.0/docs/custom-roles) defined, you may not have permission to perform some API calls.  You'll receive a `401` response code in that case.
+
+<blockquote>
+    <h3><span>❗️</span>Modifying the Origin header causes an error</h3>
+    <p>We validate that the Origin header for any API request authenticated by a session cookie matches the expected Origin header. The expected Origin header is `https://app.launchdarkly.com`.</p>
+    <p>If the Origin header does not match what's expected, we return an error. This error can prevent the LaunchDarkly app from working correctly. </p>
+    <p>Any browser extension that intentionally changes the Origin header can cause this problem. For example, the `Allow-Control-Allow-Origin: *` Chrome extension changes the Origin header to http://evil.com and causes the app to fail.</p>
+    <p>To prevent this error, do not modify your Origin header.</p>
+    <p>We do not require origin matching when authenticating with an Access Token, so this issue does not affect normal API usage.</p>
+</blockquote>
+
+# Representations
+
+All resources expect and return JSON response bodies. Error responses will also send a JSON body-- see [Errors](doc:errors) for a more detailed description of the error format used by the API. 
+
+In practice this means that you'll always get a response with a `Content-Type` header set to `application/json`.
+
+In addition, request bodies for `PUT`, `POST`, `REPORT` and `PATCH` requests must be encoded as JSON with a `Content-Type` header set to `application/json`.
+
+## Summary and detailed representations
+
+When you fetch a list of resources, the response will only include the most important attributes of each resource. This is a *summary representation* of the resource. When you fetch an individual resource (for example, a single feature flag), you'll receive a *detailed representation* containing all of the attributes of the resource.
+
+The best way to find a detailed representation is to follow links-- every summary representation includes a link to its detailed representation.
+
+## Links and addressability
+
+The best way to navigate the API is by following links-- these are attributes in representations that link to other resources. The API always uses the same format for links:
+
+* Links to other resources within the API are encapsulated in a `_links` object.
+* If the resource has a corresponding link to HTML content on the site, it is stored in a special `_site` link.
+
+Each link has two attributes: an href (the URL) and a type (the content type). For example, a feature resource might return the following:
+
+```json
+{
+    "_links": {
+        "parent": {
+            "href": "/api/features",
+            "type": "application/json"
+        },
+        "self": {
+            "href":"/api/features/sort.order",
+            "type":"application/json"
+        }
+    },
+    "_site":{
+        "href":"/features/sort.order",
+        "type":"text/html"
+    }
+}
+```
+
+From this, we can navigate to the parent collection of features by following the `parent` link, or navigate to the site page for the feature by following the `_site` link.
+
+Collections are always represented as a JSON object with an `items` attribute containing an array of representations. Like all other representations, collections will have `_links` defined at the top level.
+
+Paginated collections include `first`, `last`, `next`, and `prev` links containing a URL with the respective set of elements in the collection.
+
+# Updates
+
+Resources that accept partial updates use the `PATCH` verb, and support the [JSON Patch](http://tools.ietf.org/html/rfc6902) format. Some resources also support the  [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format. In addition, some resources support optional comments that can be submitted with updates. Comments appear in outgoing webhooks, the audit log, and other integrations.
+
+## Updates via JSON Patch
+
+[JSON Patch](http://tools.ietf.org/html/rfc6902)  is a way to specify the modifications to perform on a resource. For example, in this feature flag representation:
+
+```json
+{
+    "name": "New recommendations engine",
+    "key": "engine.enable",
+    "description": "This is the description",
+    ...
+}
+```
+
+You can change the feature flag's description with the following patch document:
+
+```json
+[
+    { "op": "replace", "path": "/description", "value": "This is the new description"}
+]
+```
+
+JSON Patch documents are always arrays. You can specify multiple modifications to perform in a single request. You can also test that certain preconditions are met before applying the patch:
+
+```json
+[
+    { "op": "test", "path": "/version", "value": 10 },
+    { "op": "replace", "path": "/description", "value": "The new description" }
+]
+```
+
+The above patch request tests whether the feature flag's `version` is `10`, and if so, changes the feature flag's description.
+
+Attributes that aren't editable, like a resource's `_links`, have names that start with an underscore.
+
+## Updates via JSON Merge Patch
+
+The API also supports the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format, as well as the [Update feature flag](doc:update-feature-flag) resource. 
+
+JSON Merge Patch is less expressive than JSON Patch but in many cases, it is simpler to construct a merge patch document. For example, you can change a feature flag's description with the following merge patch document:
+
+```json
+{
+    "description": "New flag description"
+}
+```
+
+## Updates with comments
+
+You can submit optional comments with `PATCH` changes. Currently, the [Update feature flag](doc:update-feature-flag) resource supports comments.
+
+To submit a comment along with a JSON Patch document, use the following format:
+
+```json
+{
+    "comment": "This is a comment string",
+    "patch": [ {"op": "replace", "path": "/description", "value": "The new description" } ]
+}
+```
+
+To submit a comment along with a JSON Merge Patch document, use the following format:
+
+```json
+{
+    "comment": "This is a comment string",
+    "merge": { "description": "New flag description"}
+}
+```
+
+## Updates via semantic patches
+
+The API also supports the Semantic patch format. A semantic `PATCH` is a way to specify the modifications to perform on a resource as a set of executable instructions. 
+
+JSON Patch uses paths and a limited set of operations to describe how to transform the current state of the resource into a new state. Semantic patch allows you to be explicit about intent using precise, custom instructions. In many cases, semantic patch instructions can also be defined independently of the current state of the resource. This can be useful when defining a change that may be applied at a future date.
+
+For example, in this feature flag configuration in environment Production:
+
+```json
+{
+    "name": "Alternate sort order",
+    "kind": "boolean",
+    "key": "sort.order",
+   ...
+    "environments": {
+        "production": {
+            "on": true,
+            "archived": false,
+            "salt": "c29ydC5vcmRlcg==",
+            "sel": "8de1085cb7354b0ab41c0e778376dfd3",
+            "lastModified": 1469131558260,
+            "version": 81,
+            "targets": [
+                {
+                    "values": [
+                        "Gerhard.Little@yahoo.com"
+                    ],
+                    "variation": 0
+                },
+                {
+                    "values": [
+                        "1461797806429-33-861961230",
+                        "438580d8-02ee-418d-9eec-0085cab2bdf0"
+                    ],
+                    "variation": 1
+                }
+            ],
+            "rules": [],
+            "fallthrough": {
+                "variation": 0
+            },
+            "offVariation": 1,
+            "prerequisites": [],
+            "_site": {
+                "href": "/default/production/features/sort.order",
+                "type": "text/html"
+            }
+       }
+    }
+}
+```
+
+You can add a date you want a user to be removed from the feature flag's user targets. For example,  “remove user 1461797806429-33-861961230 from the user target for variation 0 on the Alternate sort order flag in the production environment on Wed Jul 08 2020 at 15:27:41 pm”. This is done using the following:
+
+```json
+{
+    "comment": "update expiring user targets",
+    "instructions": [
+        {
+            "kind": "removeExpireUserTargetDate",
+            "userKey": "userKey",
+            "variationId": "978d53f9-7fe3-4a63-992d-97bcb4535dc8",
+        },
+        {
+            "kind": "updateExpireUserTargetDate",
+            "userKey": "userKey2",
+            "variationId": "978d53f9-7fe3-4a63-992d-97bcb4535dc8",
+            "value": 1587582000000
+        },
+        {
+            "kind": "addExpireUserTargetDate",
+            "userKey": "userKey3",
+            "variationId": "978d53f9-7fe3-4a63-992d-97bcb4535dc8",
+            "value": 1594247266386
+        }
+    ]
+}
+```
+
+Here is another example. In this feature flag configuration:
+
+```json
+{
+    "name": "New recommendations engine",
+    "key": "engine.enable",
+    "environments": {
+        "test": {
+            "on": true
+        }
+    }
+}
+```
+
+You can change the feature flag's description with the following patch document as a set of executable instructions. For example, “add user X to targets for variation Y and remove user A from targets for variation B for test flag”.
+
+```json
+{
+    "comment": "",
+    "instructions": [
+        {
+            "kind": "removeUserTargets",
+            "values": ["438580d8-02ee-418d-9eec-0085cab2bdf0"],
+            "variationId": "852cb784-54ff-46b9-8c35-5498d2e4f270"
+        },
+        {
+            "kind": "addUserTargets",
+            "values": ["438580d8-02ee-418d-9eec-0085cab2bdf0"],
+            "variationId": "1bb18465-33b6-49aa-a3bd-eeb6650b33ad"
+        }
+    ]
+}
+```
+
+<blockquote>
+    <h3><span>📘</span>Supported semantic patch API endpoints</h3>
+    <p>TODO: update these links</p>
+    <p><a href="#operation/patchFeatureFlag">Update feature flag</a></p>
+    <p><a href="">Update expiring user targets on feature flag</a></p>
+    <p><a href="">Update expiring user target for flags</a></p>
+</blockquote>
+
+# Errors
+
+TODO
+
+# CORS
+
+TODO
+
+# Rate limiting
+
+TODO
+
+# Open API (Swagger)
+
+TODO
+
+# Method Overriding
+
+TODO
+
+# Beta resources
+
+TODO
+
+# Versioning
+
+TODO

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -6,7 +6,7 @@ LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used b
 
 | Auth mechanism | Allowed resources | Use cases |
 | -------------- | ----------------- | --------- |
-| [Personal access tokens](https://docs.launchdarkly.com/v2.0/docs/api-access-tokens) | Can be customized on a per-token basis | Building scripts, custom integrations, data export |
+| [Personal access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens) | Can be customized on a per-token basis | Building scripts, custom integrations, data export |
 | SDK keys | Can only access read-only SDK-specific resources and the firehose, restricted to a single environment | Server-side SDKs, Firehose API |
 | Mobile keys | Can only access read-only mobile SDK-specific resources, restricted to a single environment | Mobile SDKs |
 | Client-side ID | Single environment, only flags marked available to client-side | Client-side JavaScript |

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -1,6 +1,6 @@
 # Authentication
 
-All REST API resources are authenticated with [personal access tokens](https://docs.launchdarkly.com/v2.0/docs/api-access-tokens) or session cookies. Other authentication mechanisms are not supported. You can manage personal access tokens on your [Account settings](https://app.launchdarkly.com/settings/tokens) page. 
+All REST API resources are authenticated with [personal access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens) or session cookies. Other authentication mechanisms are not supported. You can manage personal access tokens on your [Account settings](https://app.launchdarkly.com/settings/tokens) page. 
 
 LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used by our server-side SDKs,  mobile SDKs, and client-side JavaScript SDKs, respectively. **These keys cannot be used to access our REST API**. These keys are environment-specific, and can only perform read-only operations (fetching feature flag settings).
 
@@ -13,8 +13,8 @@ LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used b
 
 <blockquote>
     <h3><span>❗️</span>Keep your access tokens and SDK keys private</h3>
-    <p>Access tokens should *never* be exposed in untrusted contexts. Never put an access token in client-side JavaScript, or embed it in a mobile application (LaunchDarkly has special mobile keys that you can embed in mobile apps). If you accidentally expose an access token or SDK key, you can reset it from your [Account Settings](https://app.launchdarkly.com/settings#/tokens) page.</p>
-    <p>The client-side ID is safe to embed in untrusted contexts-- it's designed for use in client-side JavaScript.</p>
+    <p>Access tokens should *never* be exposed in untrusted contexts. Never put an access token in client-side JavaScript, or embed it in a mobile application. LaunchDarkly has special mobile keys that you can embed in mobile apps. If you accidentally expose an access token or SDK key, you can reset it from your [Account Settings](https://app.launchdarkly.com/settings#/tokens) page.</p>
+    <p>The client-side ID is safe to embed in untrusted contexts. It's designed for use in client-side JavaScript.</p>
 </blockquote>
 
 ## Via request header
@@ -27,34 +27,34 @@ Manage personal access tokens from the [Account Settings](https://app.launchdark
 
 For testing purposes, you can make API calls directly from your web browser. If you're logged in to the application, the API will use your existing session to authenticate calls.
 
-If you have a [role](http://docs.launchdarkly.com/v2.0/docs/teams) other than Admin, or have a [custom role](http://docs.launchdarkly.com/v2.0/docs/custom-roles) defined, you may not have permission to perform some API calls.  You'll receive a `401` response code in that case.
+If you have a [role](https://docs.launchdarkly.com/home/team/built-in-roles) other than Admin, or have a [custom role](https://docs.launchdarkly.com/home/team/custom-roles) defined, you may not have permission to perform some API calls. You will receive a `401` response code in that case.
 
 <blockquote>
     <h3><span>❗️</span>Modifying the Origin header causes an error</h3>
     <p>We validate that the Origin header for any API request authenticated by a session cookie matches the expected Origin header. The expected Origin header is `https://app.launchdarkly.com`.</p>
-    <p>If the Origin header does not match what's expected, we return an error. This error can prevent the LaunchDarkly app from working correctly. </p>
+    <p>If the Origin header does not match what's expected, LaunchDarkly returns an error. This error can prevent the LaunchDarkly app from working correctly. </p>
     <p>Any browser extension that intentionally changes the Origin header can cause this problem. For example, the `Allow-Control-Allow-Origin: *` Chrome extension changes the Origin header to http://evil.com and causes the app to fail.</p>
     <p>To prevent this error, do not modify your Origin header.</p>
-    <p>We do not require origin matching when authenticating with an Access Token, so this issue does not affect normal API usage.</p>
+    <p>LaunchDarkly does not require origin matching when authenticating with an Access Token, so this issue does not affect normal API usage.</p>
 </blockquote>
 
 # Representations
 
-All resources expect and return JSON response bodies. Error responses will also send a JSON body-- see [Errors](doc:errors) for a more detailed description of the error format used by the API. 
+All resources expect and return JSON response bodies. Error responses will also send a JSON body. Read [Errors](doc:errors) for a more detailed description of the error format used by the API. 
 
-In practice this means that you'll always get a response with a `Content-Type` header set to `application/json`.
+In practice this means that you always get a response with a `Content-Type` header set to `application/json`.
 
 In addition, request bodies for `PUT`, `POST`, `REPORT` and `PATCH` requests must be encoded as JSON with a `Content-Type` header set to `application/json`.
 
 ## Summary and detailed representations
 
-When you fetch a list of resources, the response will only include the most important attributes of each resource. This is a *summary representation* of the resource. When you fetch an individual resource (for example, a single feature flag), you'll receive a *detailed representation* containing all of the attributes of the resource.
+When you fetch a list of resources, the response includes only the most important attributes of each resource. This is a *summary representation* of the resource. When you fetch an individual resource (for example, a single feature flag), you receive a *detailed representation* containing all of the attributes of the resource.
 
-The best way to find a detailed representation is to follow links-- every summary representation includes a link to its detailed representation.
+The best way to find a detailed representation is to follow links. Every summary representation includes a link to its detailed representation.
 
 ## Links and addressability
 
-The best way to navigate the API is by following links-- these are attributes in representations that link to other resources. The API always uses the same format for links:
+The best way to navigate the API is by following links. These are attributes in representations that link to other resources. The API always uses the same format for links:
 
 * Links to other resources within the API are encapsulated in a `_links` object.
 * If the resource has a corresponding link to HTML content on the site, it is stored in a special `_site` link.
@@ -80,9 +80,9 @@ Each link has two attributes: an href (the URL) and a type (the content type). F
 }
 ```
 
-From this, we can navigate to the parent collection of features by following the `parent` link, or navigate to the site page for the feature by following the `_site` link.
+From this, you can navigate to the parent collection of features by following the `parent` link, or navigate to the site page for the feature by following the `_site` link.
 
-Collections are always represented as a JSON object with an `items` attribute containing an array of representations. Like all other representations, collections will have `_links` defined at the top level.
+Collections are always represented as a JSON object with an `items` attribute containing an array of representations. Like all other representations, collections have `_links` defined at the top level.
 
 Paginated collections include `first`, `last`, `next`, and `prev` links containing a URL with the respective set of elements in the collection.
 
@@ -92,7 +92,7 @@ Resources that accept partial updates use the `PATCH` verb, and support the [JSO
 
 ## Updates via JSON Patch
 
-[JSON Patch](http://tools.ietf.org/html/rfc6902)  is a way to specify the modifications to perform on a resource. For example, in this feature flag representation:
+[JSON Patch](http://tools.ietf.org/html/rfc6902) is a way to specify the modifications to perform on a resource. For example, in this feature flag representation:
 
 ```json
 {
@@ -138,7 +138,7 @@ JSON Merge Patch is less expressive than JSON Patch but in many cases, it is sim
 
 ## Updates with comments
 
-You can submit optional comments with `PATCH` changes. Currently, the [Update feature flag](doc:update-feature-flag) resource supports comments.
+You can submit optional comments with `PATCH` changes. The [Update feature flag](doc:update-feature-flag) resource supports comments.
 
 To submit a comment along with a JSON Patch document, use the following format:
 
@@ -210,7 +210,7 @@ For example, in this feature flag configuration in environment Production:
 }
 ```
 
-You can add a date you want a user to be removed from the feature flag's user targets. For example,  “remove user 1461797806429-33-861961230 from the user target for variation 0 on the Alternate sort order flag in the production environment on Wed Jul 08 2020 at 15:27:41 pm”. This is done using the following:
+You can add a date you want a user to be removed from the feature flag's user targets. For example, “remove user 1461797806429-33-861961230 from the user target for variation 0 on the Alternate sort order flag in the production environment on Wed Jul 08 2020 at 15:27:41 pm”. This is done using the following:
 
 ```json
 {
@@ -251,7 +251,7 @@ Here is another example. In this feature flag configuration:
 }
 ```
 
-You can change the feature flag's description with the following patch document as a set of executable instructions. For example, “add user X to targets for variation Y and remove user A from targets for variation B for test flag”.
+You can change the feature flag's description with the following patch document as a set of executable instructions. For example, “add user X to targets for variation Y and remove user A from targets for variation B for test flag”:
 
 ```json
 {
@@ -297,15 +297,15 @@ The general class of error is indicated by the `code`. The `message` is a human-
 
 | Code | Definition | Desc. | Possible Solution |
 | ---- | ---------- | ----- | ----------------- |
-| 400  | Bad Request | A request that fails may return this HTTP response code | Ensure JSON syntax in request body is correct. |
-| 401  | Unauthorized | User doesn't have permission to an API call | Ensure your SDK key is good. |
+| 400  | Bad Request | A request that fails may return this HTTP response code. | Ensure JSON syntax in request body is correct. |
+| 401  | Unauthorized | User doesn't have permission to an API call. | Ensure your SDK key is good. |
 | 403  | Forbidden | User does not have permission for operation. | Ensure that the user or access token has proper permissions set. |
 | 409  | Conflict | The API request could not be completed because it conflicted with a concurrent API request. | Retry your request. |
-| 429  | Too many requests | See [Rate limiting](ref:rate-limiting) | Wait and try again later. |
+| 429  | Too many requests | See [Rate limiting](ref:rate-limiting). | Wait and try again later. |
 
 # CORS
 
-The LaunchDarkly API supports Cross Origin Resource Sharing (CORS) for AJAX requests from any origin.  If an `Origin` header is given in a request, it will be echoed as an explicitly allowed origin. Otherwise, a wildcard will be returned: `Access-Control-Allow-Origin: *`.  For more information on CORS, see the [CORS W3C Recommendation](http://www.w3.org/TR/cors).  Example CORS headers might look like:
+The LaunchDarkly API supports Cross Origin Resource Sharing (CORS) for AJAX requests from any origin.  If an `Origin` header is given in a request, it will be echoed as an explicitly allowed origin. Otherwise, a wildcard is returned: `Access-Control-Allow-Origin: *`.  For more information on CORS, see the [CORS W3C Recommendation](http://www.w3.org/TR/cors). Example CORS headers might look like:
 
 ```http
 Access-Control-Allow-Headers: Accept, Content-Type, Content-Length, Accept-Encoding, Authorization
@@ -314,7 +314,7 @@ Access-Control-Allow-Origin: *
 Access-Control-Max-Age: 300
 ```
 
-You can make authenticated CORS calls just as you would make same-origin calls, using either [token or session-based authentication](doc:authentication). If you’re using session auth, you should set the `withCredentials` property for your `xhr` request to `true`. Remember-- you should never expose your access tokens to untrusted users.
+You can make authenticated CORS calls just as you would make same-origin calls, using either [token or session-based authentication](doc:authentication). If you’re using session auth, you should set the `withCredentials` property for your `xhr` request to `true`. You should never expose your access tokens to untrusted users.
 
 # Rate limiting
 
@@ -322,20 +322,20 @@ We use several rate limiting strategies to ensure the availability of our APIs. 
 
 <blockquote>
     <h3><span>❗️</span>Rate limiting and SDKs</h3>
-    <p>Our SDKs are never rate limited. Our SDKs do not use the API endpoints defined here-- we use a different set of approaches (streaming / server-sent events as well as a global CDN) to ensure availability to the routes used by our SDKs.</p>
-    <p>The client-side ID is safe to embed in untrusted contexts-- it's designed for use in client-side JavaScript.</p>
+    <p>Our SDKs are never rate limited. Our SDKs do not use the API endpoints defined here. We use a different set of approaches, including streaming/server-sent events and a global CDN, to ensure availability to the routes used by our SDKs.</p>
+    <p>The client-side ID is safe to embed in untrusted contexts. It's designed for use in client-side JavaScript.</p>
 </blockquote>
 
 ## Global rate limits
 
-Authenticated requests are subject to a global limit-- this is the maximum number of calls that can be made to the API per ten seconds. All personal access tokens on the account share this limit, so exceeding the limit with one access token will impact other tokens. Calls that are subject to global rate limits will return the headers below:
+Authenticated requests are subject to a global limit. This is the maximum number of calls that can be made to the API per ten seconds. All personal access tokens on the account share this limit, so exceeding the limit with one access token will impact other tokens. Calls that are subject to global rate limits will return the headers below:
 
 | Header name | Description |
 | ----------- | ----------- |
 | `X-Ratelimit-Global-Remaining` | The maximum number of requests the account is permitted to make per ten seconds. |
 | `X-Ratelimit-Reset` | The time at which the current rate limit window resets in epoch milliseconds. |
 
-We do not publicly document the specific number of calls that can be made globally. This limit may change, and we encourage clients to program against the specification (relying on the two headers defined above) rather than hardcoding to the current limit.
+We do not publicly document the specific number of calls that can be made globally. This limit may change, and we encourage clients to program against the specification, relying on the two headers defined above, rather than hardcoding to the current limit.
 
 ## Route-level rate limits
 
@@ -348,13 +348,13 @@ Some authenticated routes have custom rate limits. These also reset every ten se
 
 A *route* represents a specific URL pattern and verb. For example, the [Delete environment](doc:delete-environment) endpoint is considered a single route, and each call to delete an environment counts against your route-level rate limit for that route. 
 
-We do not publicly document the specific number of calls that can be made to each endpoint per ten seconds. These limits may change, and we encourage clients to program against the specification (relying on the two headers defined above) rather than hardcoding to the current limits.
+We do not publicly document the specific number of calls that can be made to each endpoint per ten seconds. These limits may change, and we encourage clients to program against the specification, relying on the two headers defined above, rather than hardcoding to the current limits.
 
 ## IP-based rate limiting
 
 We also employ IP-based rate limiting on some API routes. If you hit an IP-based rate limit, your API response will include a `Retry-After` header indicating how long to wait before re-trying the call. Clients must wait at least `Retry-After` seconds before making additional calls to our API, and should employ jitter and backoff strategies to avoid triggering rate limits again.
 
-# Open API (Swagger)
+# OpenAPI (Swagger)
 
 We have a complete Open API (Swagger) specification for our API hosted here:
 
@@ -366,7 +366,7 @@ You can use this specification to generate client libraries to interact with our
 
 # Client libraries
 
-Our client libraries, in addition to community-supported clients, are available on [GitHub](https://github.com/search?q=topic%3Alaunchdarkly-api+org%3Alaunchdarkly&type=Repositories).
+We auto-generate multiple client libraries based on our OpenAPI specification. To learn more, visit [GitHub](https://github.com/search?q=topic%3Alaunchdarkly-api+org%3Alaunchdarkly&type=Repositories).
 
 # Method Overriding
 
@@ -410,13 +410,13 @@ See new versions in the [Changelog](ref:changelog).
 
 ## Setting the API version per request
 
-You can set the API version on a specific request by sending an `LD-API-Version` header, as shown in the example below
+You can set the API version on a specific request by sending an `LD-API-Version` header, as shown in the example below:
 
 ```
 LD-API-Version: 20191212
 ```
 
-The header value is the version number of the API version you'd like to request. The number for each version corresponds to the date the version was released; in the example above the version `20191212` corresponds to December 12, 2019. 
+The header value is the version number of the API version you'd like to request. The number for each version corresponds to the date the version was released. In the example above the version `20191212` corresponds to December 12, 2019. 
 
 ## Setting the API version per access token
 
@@ -434,5 +434,5 @@ If you would like to upgrade your integration to use a new API version, you can 
 
 <blockquote>
     <h3><span>🚧</span>API Path Versioning</h3>
-    <p>In the past, we've used path-based API versioning (e.g. versioning resources by adding `v2` to endpoint URLs). We don't foresee the need to do this again, but reserve the right to do so if we find the need to make major revisions to the API.</p>
+    <p>In the past, we've used path-based API versioning. For example, versioning resources by adding `v2` to endpoint URLs. We don't foresee the need to do this again, but may do so if we need to make major revisions to the API.</p>
 </blockquote>

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -358,8 +358,6 @@ We also employ IP-based rate limiting on some API routes. If you hit an IP-based
 
 We have a [complete OpenAPI (Swagger) specification](https://app.launchdarkly.com/api/v2/openapi.json) for our API.
 
-This specification is generated from the [ld-openapi repository on GitHub](https://github.com/launchdarkly/ld-openapi). 
-
 You can use this specification to generate client libraries to interact with our REST API in your language of choice. 
 
 # Client libraries

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -356,9 +356,7 @@ We also employ IP-based rate limiting on some API routes. If you hit an IP-based
 
 # OpenAPI (Swagger)
 
-We have a complete Open API (Swagger) specification for our API hosted here:
-
-[LaunchDarkly OpenAPI specification](https://launchdarkly.github.io/ld-openapi/openapi.yaml)
+We have a [complete OpenAPI (Swagger) specification](https://app.launchdarkly.com/api/v2/openapi.json) for our API.
 
 This specification is generated from the [ld-openapi repository on GitHub](https://github.com/launchdarkly/ld-openapi). 
 

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -2,7 +2,7 @@
 
 All REST API resources are authenticated with [personal access tokens](https://docs.launchdarkly.com/home/account-security/api-access-tokens) or session cookies. Other authentication mechanisms are not supported. You can manage personal access tokens on your [Account settings](https://app.launchdarkly.com/settings/tokens) page. 
 
-LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used by our server-side SDKs,  mobile SDKs, and client-side JavaScript SDKs, respectively. **These keys cannot be used to access our REST API**. These keys are environment-specific, and can only perform read-only operations (fetching feature flag settings).
+LaunchDarkly also has SDK keys, mobile keys, and client-side IDs that are used by our server-side SDKs, mobile SDKs, and client-side JavaScript SDKs, respectively. **These keys cannot be used to access our REST API**. These keys are environment-specific, and can only perform read-only operations (fetching feature flag settings).
 
 | Auth mechanism | Allowed resources | Use cases |
 | -------------- | ----------------- | --------- |
@@ -88,7 +88,7 @@ Paginated collections include `first`, `last`, `next`, and `prev` links containi
 
 # Updates
 
-Resources that accept partial updates use the `PATCH` verb, and support the [JSON Patch](http://tools.ietf.org/html/rfc6902) format. Some resources also support the  [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format. In addition, some resources support optional comments that can be submitted with updates. Comments appear in outgoing webhooks, the audit log, and other integrations.
+Resources that accept partial updates use the `PATCH` verb, and support the [JSON Patch](http://tools.ietf.org/html/rfc6902) format. Some resources also support the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format. In addition, some resources support optional comments that can be submitted with updates. Comments appear in outgoing webhooks, the audit log, and other integrations.
 
 ## Updates via JSON Patch
 
@@ -291,7 +291,7 @@ The API always returns errors in a common format. Here's an example:
 }
 ```
 
-The general class of error is indicated by the `code`. The `message` is a human-readable explanation of what went wrong. The `id` is a unique identifier-- use it when you're working with LaunchDarkly support to debug a problem with a specific API call.
+The general class of error is indicated by the `code`. The `message` is a human-readable explanation of what went wrong. The `id` is a unique identifier. Use it when you're working with LaunchDarkly support to debug a problem with a specific API call.
 
 ## HTTP Status - Error Response Codes
 
@@ -305,7 +305,7 @@ The general class of error is indicated by the `code`. The `message` is a human-
 
 # CORS
 
-The LaunchDarkly API supports Cross Origin Resource Sharing (CORS) for AJAX requests from any origin.  If an `Origin` header is given in a request, it will be echoed as an explicitly allowed origin. Otherwise, a wildcard is returned: `Access-Control-Allow-Origin: *`.  For more information on CORS, see the [CORS W3C Recommendation](http://www.w3.org/TR/cors). Example CORS headers might look like:
+The LaunchDarkly API supports Cross Origin Resource Sharing (CORS) for AJAX requests from any origin. If an `Origin` header is given in a request, it will be echoed as an explicitly allowed origin. Otherwise, a wildcard is returned: `Access-Control-Allow-Origin: *`. For more information on CORS, see the [CORS W3C Recommendation](http://www.w3.org/TR/cors). Example CORS headers might look like:
 
 ```http
 Access-Control-Allow-Headers: Accept, Content-Type, Content-Length, Accept-Encoding, Authorization

--- a/apidocs/overview.md
+++ b/apidocs/overview.md
@@ -40,7 +40,7 @@ If you have a [role](https://docs.launchdarkly.com/home/team/built-in-roles) oth
 
 # Representations
 
-All resources expect and return JSON response bodies. Error responses will also send a JSON body. Read [Errors](doc:errors) for a more detailed description of the error format used by the API. 
+All resources expect and return JSON response bodies. Error responses will also send a JSON body. Read [Errors](#section/Errors) for a more detailed description of the error format used by the API. 
 
 In practice this means that you always get a response with a `Content-Type` header set to `application/json`.
 
@@ -126,7 +126,7 @@ Attributes that aren't editable, like a resource's `_links`, have names that sta
 
 ## Updates via JSON Merge Patch
 
-The API also supports the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format, as well as the [Update feature flag](doc:update-feature-flag) resource. 
+The API also supports the [JSON Merge Patch](https://tools.ietf.org/html/rfc7386) format, as well as the [Update feature flag](#operation/patchFeatureFlag) resource. 
 
 JSON Merge Patch is less expressive than JSON Patch but in many cases, it is simpler to construct a merge patch document. For example, you can change a feature flag's description with the following merge patch document:
 
@@ -138,7 +138,7 @@ JSON Merge Patch is less expressive than JSON Patch but in many cases, it is sim
 
 ## Updates with comments
 
-You can submit optional comments with `PATCH` changes. The [Update feature flag](doc:update-feature-flag) resource supports comments.
+You can submit optional comments with `PATCH` changes. The [Update feature flag](#operation/patchFeatureFlag) resource supports comments.
 
 To submit a comment along with a JSON Patch document, use the following format:
 
@@ -314,7 +314,7 @@ Access-Control-Allow-Origin: *
 Access-Control-Max-Age: 300
 ```
 
-You can make authenticated CORS calls just as you would make same-origin calls, using either [token or session-based authentication](doc:authentication). If you’re using session auth, you should set the `withCredentials` property for your `xhr` request to `true`. You should never expose your access tokens to untrusted users.
+You can make authenticated CORS calls just as you would make same-origin calls, using either [token or session-based authentication](#section/Authentication). If you’re using session auth, you should set the `withCredentials` property for your `xhr` request to `true`. You should never expose your access tokens to untrusted users.
 
 # Rate limiting
 
@@ -346,7 +346,7 @@ Some authenticated routes have custom rate limits. These also reset every ten se
 | `X-Ratelimit-Route-Remaining` | The maximum number of requests to the current route the account is permitted to make per ten seconds. |
 | `X-Ratelimit-Reset` | The time at which the current rate limit window resets in epoch milliseconds. |
 
-A *route* represents a specific URL pattern and verb. For example, the [Delete environment](doc:delete-environment) endpoint is considered a single route, and each call to delete an environment counts against your route-level rate limit for that route. 
+A *route* represents a specific URL pattern and verb. For example, the [Delete environment](#operation/deleteEnvironment) endpoint is considered a single route, and each call to delete an environment counts against your route-level rate limit for that route. 
 
 We do not publicly document the specific number of calls that can be made to each endpoint per ten seconds. These limits may change, and we encourage clients to program against the specification, relying on the two headers defined above, rather than hardcoding to the current limits.
 

--- a/apidocs/projects.md
+++ b/apidocs/projects.md
@@ -1,0 +1,3 @@
+Projects allow you to manage multiple different software projects under one LaunchDarkly account. Each project has its own unique set of environments and feature flags. 
+
+Using the Projects API, you can create, destroy, and manage projects.

--- a/apidocs/scheduled-changes.md
+++ b/apidocs/scheduled-changes.md
@@ -1,3 +1,3 @@
 Schedule the specified flag targeting changes to take effect at the selected time. You may schedule multiple changes for a flag each with a different `ExecutionDate`.
 
-Note that the supported flag actions currently include enabling/disabling targeting, changing the default rule, and changing the `off` variation. If you include unsupported actions as part of your scheduled changes, they will be discarded.
+The supported flag actions include enabling/disabling targeting, changing the default rule, and changing the `off` variation. If you include unsupported actions as part of your scheduled changes, they will be discarded.

--- a/apidocs/scheduled-changes.md
+++ b/apidocs/scheduled-changes.md
@@ -1,0 +1,3 @@
+Schedule the specified flag targeting changes to take effect at the selected time. You may schedule multiple changes for a flag each with a different `ExecutionDate`.
+
+Note that the supported flag actions currently include enabling/disabling targeting, changing the default rule, and changing the `off` variation. If you include unsupported actions as part of your scheduled changes, they will be discarded.

--- a/apidocs/segments.md
+++ b/apidocs/segments.md
@@ -1,0 +1,3 @@
+Segments allow you to create targeting rules and lists of users that can be shared by one or more feature flags in an environment. Creating a segment is a lot like creating a flag. You can include individual users from a segment. You can also create targeting rules, same as those for flags, that include or exclude users based on attributes your application has provided about those users. Finally, you can explicitly exclude users that would otherwise be included by those rules.
+
+The segments API allows you to list, create, modify, and delete segments programmatically.

--- a/apidocs/team-members.md
+++ b/apidocs/team-members.md
@@ -1,0 +1,3 @@
+The Team Members API allows you to invite new members to a team by making a POST request to /api/v2/members.  When you invite a new member to a team, an invitation will be sent to the email you have provided.  Members with "admin" or "owner" roles may create new members, as well as anyone with a "createMember" permission for "member/*".
+
+Any member may request the complete list of team members with a GET to /api/v2/members.

--- a/apidocs/user-settings.md
+++ b/apidocs/user-settings.md
@@ -1,0 +1,3 @@
+LaunchDarkly's User Settings API provides a picture of all feature flags and their current values for a specific user. This gives you instant visibility of how a particular user is experiencing your site or application.
+
+The User Settings API can also be used to assign a user to a specific variation for any feature flag.

--- a/apidocs/users.md
+++ b/apidocs/users.md
@@ -1,0 +1,5 @@
+LaunchDarkly creates a record for each user passed in to `variation` calls. This record powers the autocomplete functionality on the Feature Flag management page, as well as the Users page.
+
+LaunchDarkly also offers an API that lets you tap into this data. You can use the users API to see what user data is available to LaunchDarkly, as well as determine which flag values a user will receive. You can also explicitly set which flag value a user will receive via this API.
+
+Users are always scoped within a project and environment. In other words, each environment has its own set of user records.


### PR DESCRIPTION
This adds a set of markdown files based on the [readme.io documentation](https://apidocs.launchdarkly.com/). They are not intended to be integrated directly into our docs, they are intended to be consumed by redocly when it generates API documentation based on our openAPI spec. These markdown files represent the general documentation at the top of our API docs, and at the top of each section.

They are not consumed by redocly yet, this is just a first step towards that goal - migrating them from readme.io into separate md files. Basically they need to be hosted somewhere that redocly can get them - it doesn't have to be in this repo, but I thought it wasn't a bad place for now - more than happy to consider alternatives ofc.

The only direct change I made was updating the link to our client libraries, and promoting that link to have its own section for better exposure.