### PR TITLE
Remove beta banner for Metrics 

### DIFF
--- a/apidocs/metrics.md
+++ b/apidocs/metrics.md
@@ -1,8 +1,3 @@
-<blockquote>
-    <h3><span>📘</span>This feature is currently in beta</h3>
-    <p>To use this feature, pass in a header including the `LD-API-Version` key with value set to `beta`. Use this header with each call.</p>
-</blockquote>
-
 Metrics track flag behavior over time when an experiment is running. The data generated from experiments gives you more insight into the impact of a particular flag.
 
 Using the Metrics API, you can create, delete, and manage metrics.


### PR DESCRIPTION
Metrics endpoints don't require the beta header. 