### PR TITLE
Remove EAP callout for experiment allocation

### DIFF
--- a/src/content/topics/home/experimentation/managing/allocation.mdx
+++ b/src/content/topics/home/experimentation/managing/allocation.mdx
@@ -5,15 +5,6 @@ description: 'This topic explains how to include users in an experiment using ex
 published: true
 ---
 
-<Callout intent="info">
-<CalloutTitle>This feature is for Early Access Program customers only</CalloutTitle>
-<CalloutDescription>
-
-Experiment allocation is only available to members of LaunchDarkly's Early Access Program (EAP). If you want access to this feature, [join the EAP](https://docs.google.com/forms/d/e/1FAIpQLScJ5qCC_RZTW9pPSXVZk9HaKzpltNAeoQb2t6gh7dLicwQWQQ/viewform).
-
-</CalloutDescription>
-</Callout>
-
 ## Overview
 
 This topic explains how to include users in an experiment using experiment allocation.


### PR DESCRIPTION
This is no longer an EAP product, and I'd like to remove the callout here.

P.S. I've only ever been able to comment on PRs, so this is my first actual submission. Hope I'm doing this right :mildpanic: