### PR TITLE
Update allocation matrix for Android support

### DIFF
--- a/src/content/topics/home/experimentation/managing/allocation.mdx
+++ b/src/content/topics/home/experimentation/managing/allocation.mdx
@@ -25,7 +25,7 @@ Client-side SDKs:
   <TableBody>
     <TableRow>
       <TableCell>Android</TableCell>
-      <TableCell>Not supported</TableCell>
+      <TableCell>3.1.0</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>C/C++</TableCell>


### PR DESCRIPTION
Android version 3.1.0 now supports allocation, so we should update the matrix

- https://github.com/launchdarkly/android-client-sdk/releases/tag/3.1.0
- https://launchdarkly.slack.com/archives/C01G0D91W8K/p1628301680021000?thread_ts=1628209949.017500&cid=C01G0D91W8K