### PR TITLE
Update React Native version

### DIFF
--- a/src/content/topics/home/experimentation/managing/allocation.mdx
+++ b/src/content/topics/home/experimentation/managing/allocation.mdx
@@ -57,7 +57,7 @@ Client-side SDKs:
     </TableRow>
     <TableRow>
       <TableCell>React Native</TableCell>
-      <TableCell>Not supported</TableCell>
+      <TableCell>5.0.0</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>Roku</TableCell>


### PR DESCRIPTION
React Native is now supported after version 5.0.0. Updating from "not supported"