### PR TITLE
Remove enumeration of mParticle id options 

### DIFF
--- a/src/content/topics/home/data-export/mparticle.mdx
+++ b/src/content/topics/home/data-export/mparticle.mdx
@@ -52,7 +52,7 @@ To create an mParticle destination in LaunchDarkly:
 ![The Create a destination screen.](../../images/mparticle-destination-create.png)
 
 
-8. Select a **User identifier** type from the dropdown as shown below
+8. Select a **User identifier** type from the dropdown as shown below.
 
 ![The User identifier dropdown.](../../images/mparticle-user-id.png)
 

--- a/src/content/topics/home/data-export/mparticle.mdx
+++ b/src/content/topics/home/data-export/mparticle.mdx
@@ -52,15 +52,7 @@ To create an mParticle destination in LaunchDarkly:
 ![The Create a destination screen.](../../images/mparticle-destination-create.png)
 
 
-8. Select a **User identifier** type from the dropdown. Choose from the following options:
-
-- customer_id
-- email
-- facebook
-- twitter
-- google
-
-Here is an image of the User identifier dropdown:
+8. Select a **User identifier** type from the dropdown as shown below
 
 ![The User identifier dropdown.](../../images/mparticle-user-id.png)
 
@@ -78,13 +70,7 @@ To learn more about exported events, read [Schema reference](/home/data-export/s
 </CalloutDescription>
 </Callout>
 
-10. (Optional) Select an **Anonymous user identifier** type from the dropdown. Choose from the following options:
-
-- customer_id
-- email
-- facebook
-- twitter
-- google
+10. (Optional) Select an **Anonymous user identifier** type from the dropdown. 
 
  Anonymous user identifiers let you use an `alias` event to  connect two user IDs that represent the same person. To learn more about `alias` events, read [Associating anonymous users with logged in users](/home/users/anonymous-users#associating-anonymous-users-with-logged-in-users).
 


### PR DESCRIPTION
 These were out of date and it seems unnecessary to include them.