### PR TITLE
Remove Flutter from SDKs table

### DIFF
--- a/src/content/topics/home/experimentation/managing/allocation.mdx
+++ b/src/content/topics/home/experimentation/managing/allocation.mdx
@@ -36,10 +36,6 @@ Client-side SDKs:
       <TableCell>All versions</TableCell>
     </TableRow>
     <TableRow>
-      <TableCell>Flutter</TableCell>
-      <TableCell>Not supported</TableCell>
-    </TableRow>
-    <TableRow>
       <TableCell>iOS</TableCell>
       <TableCell>All versions</TableCell>
     </TableRow>


### PR DESCRIPTION
I learned from @bwoskow-ld that Flutter isn't even officially supported by LD at large right now, so we should remove this callout from the Traffic Allocation support table.