### PR TITLE
Add missing word

### DIFF
--- a/src/content/topics/sdk/client-side/ios/index.mdx
+++ b/src/content/topics/sdk/client-side/ios/index.mdx
@@ -312,7 +312,7 @@ config.backgroundFlagPollingInterval = 3600
 </CodeTabItem>
 </CodeTabs>
 
-Lastly, down the client when your application terminates. To learn more, read [Shutting down](/sdk/features/shutdown#ios).
+Lastly, shut down the client when your application terminates. To learn more, read [Shutting down](/sdk/features/shutdown#ios).
 
 ## Data collection
 


### PR DESCRIPTION
Add missing "shut" to this sentence. 