### PR TITLE
Fix mis-documented prop type for client

### DIFF
--- a/src/content/topics/sdk/client-side/react/react-web.mdx
+++ b/src/content/topics/sdk/client-side/react/react-web.mdx
@@ -184,7 +184,7 @@ In the React SDK streaming mode is enabled by default. To disable streaming mode
 
 ## `withLDConsumer`
 
-The return value of `withLDConsumer` is a wrapper function that takes your component and returns a React component injected with `flags` & `client` as props.
+The return value of `withLDConsumer` is a wrapper function that takes your component and returns a React component injected with `flags` & `ldClient` as props.
 
 Here's how:
 
@@ -199,7 +199,7 @@ Here's how:
 ```js
 import { withLDConsumer } from 'launchdarkly-react-client-sdk';
 
-const Home = ({ flags, client /*, ...otherProps */ }) => {
+const Home = ({ flags, ldClient /*, ...otherProps */ }) => {
   // You can call any of the methods from the JavaScript SDK
   // client.identify({...})
 


### PR DESCRIPTION
Should be `ldClient` instead of `client`