### PR TITLE
Updated events differences

### DIFF
--- a/src/content/topics/sdk/concepts/domains.mdx
+++ b/src/content/topics/sdk/concepts/domains.mdx
@@ -25,7 +25,7 @@ The following table describes the default base URIs for each service and SDK:
   <TableHeader>
     <TableHeadCell>Service</TableHeadCell>
     <TableHeadCell>Server-side SDKs</TableHeadCell>
-    <TableHeadCell>Client-side JS SDKs</TableHeadCell>
+    <TableHeadCell>Client-side JavaScript SDKs</TableHeadCell>
     <TableHeadCell>Mobile SDKs</TableHeadCell>
   </TableHeader>
   <TableBody>

--- a/src/content/topics/sdk/concepts/domains.mdx
+++ b/src/content/topics/sdk/concepts/domains.mdx
@@ -25,21 +25,25 @@ The following table describes the default base URIs for each service and SDK:
   <TableHeader>
     <TableHeadCell>Service</TableHeadCell>
     <TableHeadCell>Server-side SDKs</TableHeadCell>
-    <TableHeadCell>Client-side or mobile SDKs</TableHeadCell>
+    <TableHeadCell>Client-side JS SDKs</TableHeadCell>
+    <TableHeadCell>Mobile SDKs</TableHeadCell>
   </TableHeader>
   <TableBody>
   <TableRow>
     <TableCell>Streaming</TableCell>
     <TableCell>https://stream.launchdarkly.com</TableCell>
     <TableCell>https://clientstream.launchdarkly.com</TableCell>
+    <TableCell>https://clientstream.launchdarkly.com</TableCell>
   </TableRow>
   <TableRow>
     <TableCell>Polling</TableCell>
     <TableCell>https://sdk.launchdarkly.com or https://app.launchdarkly.com</TableCell>
     <TableCell>https://clientsdk.launchdarkly.com or https://app.launchdarkly.com</TableCell>
+    <TableCell>https://clientsdk.launchdarkly.com or https://app.launchdarkly.com</TableCell>
   </TableRow>
   <TableRow>
     <TableCell>Events</TableCell>
+    <TableCell>https://events.launchdarkly.com</TableCell>
     <TableCell>https://events.launchdarkly.com</TableCell>
     <TableCell>https://mobile.launchdarkly.com</TableCell>
   </TableRow>


### PR DESCRIPTION
Mobile SDKs and client-side JS SDKs use different events domains. Instead of adding a third column, we could also condense this info into two columns like before.


<!--
Does this PR need to be scheduled?

You can schedule the merge and publication of this PR if the contents are time-sensitive. If you're not yet certain of the release date, no action is required. You can always add the schedule command later, or merge the PR manually. 

To learn how, read [Scheduling a PR merge to main](https://github.com/launchdarkly/git-gatsby/blob/main/README.md#internal-launchdarkly-use-only-scheduling-a-pr-merge-to-main).

-->
