### PR TITLE
Add code reference filter and count information

### DIFF
--- a/src/content/topics/home/flags-in-codebase/code-references/index.mdx
+++ b/src/content/topics/home/flags-in-codebase/code-references/index.mdx
@@ -57,6 +57,18 @@ To set up code references in LaunchDarkly, you must have the following prerequis
 
 You can view existing code references for feature flags in the flag dashboard. To view existing code references, visit a feature flag's **Code references** tab.
 
+You can visit this page either by clicking the tab when viewing a flag page, or directly by clicking the code reference count on the flag dashboard.
+
+<Callout intent="info">
+<CalloutTitle>Code reference count may not be visible</CalloutTitle>
+<CalloutDescription>
+
+ Code reference count shows when there is at least one code reference for that flag, or when [filtering by code reference count](/home/organize/dashboard#filtering-feature-flags)
+
+</CalloutDescription>
+</Callout>
+
+
 The screenshot below shows the **Code references** tab displaying an active code reference:
 
 ![The "Code references" tab of a feature flag.](flag-code-references.png)

--- a/src/content/topics/home/flags-in-codebase/code-references/index.mdx
+++ b/src/content/topics/home/flags-in-codebase/code-references/index.mdx
@@ -63,7 +63,7 @@ You can visit this page either by clicking the tab when viewing a flag page, or 
 <CalloutTitle>Code reference count may not be visible</CalloutTitle>
 <CalloutDescription>
 
- Code reference count shows when there is at least one code reference for that flag, or when [filtering by code reference count](/home/organize/dashboard#filtering-feature-flags)
+ Code reference count shows when there is at least one code reference for that flag, or when you filter by code reference count. To learn more, read [Filtering feature flags](/home/organize/dashboard#filtering-feature-flags).
 
 </CalloutDescription>
 </Callout>

--- a/src/content/topics/home/organizing-flags/dashboard.mdx
+++ b/src/content/topics/home/organizing-flags/dashboard.mdx
@@ -17,6 +17,16 @@ Here is an image of the flag dashboard:
 
 ![The flag dashboard.](flags-dashboard.png)
 
+<Callout intent="info">
+<CalloutTitle>Flag dashboard features vary by plan</CalloutTitle>
+<CalloutDescription>
+
+  To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).
+  
+
+</CalloutDescription>
+</Callout>
+
 To learn how to create a new flag, read [Creating a feature flag](/home/getting-started/feature-flags#creating-a-feature-flag). To learn how to archive a flag, read [Archiving flags](/home/code/flag-archive#archiving-flags).
 
 Use the search bar to find a flag by name, tag, key, or description. You can sort the list of visible flags to identify the oldest or most recent, or to view them in alphabetical order. By default, the most recently created flags appear first.


### PR DESCRIPTION
This PR seeks to let the users know that:
- It's possible to filter by code reference count
- It's possible to click on the code reference count in the dashboard to view code reference tab