### PR TITLE
Add link to hello-clojure in Java SDK reference

### DIFF
--- a/src/content/topics/sdk/server-side/java/index.mdx
+++ b/src/content/topics/sdk/server-side/java/index.mdx
@@ -32,7 +32,7 @@ LaunchDarkly's SDKs are open source. In addition to this reference guide, we pro
     </TableRow>
     <TableRow>
       <TableCell>Sample applications</TableCell>
-      <TableCell><a href="https://github.com/launchdarkly/hello-java">hello-java</a> (Java)<br/> <a href="https://github.com/launchdarkly/hello-scala">hello-scala</a> (Scala) <br/> You can also use this SDK with <a href="https://kotlinlang.org/">Kotlin</a></TableCell>
+      <TableCell><a href="https://github.com/launchdarkly/hello-java">hello-java</a> (Java)<br/> <a href="https://github.com/launchdarkly/hello-scala">hello-scala</a> (Scala) <br/> <a href="https://github.com/launchdarkly/hello-clojure">hello-clojure</a> (Clojure) <br/> You can also use this SDK with <a href="https://kotlinlang.org/">Kotlin</a></TableCell>
     </TableRow>
     <TableRow>
       <TableCell>Published module</TableCell>


### PR DESCRIPTION
Adds a link to the new [hello-clojure](https://github.com/launchdarkly/LaunchDarkly-Docs) project.