### PR TITLE
clarify that the user must be a hash in ruby

### DIFF
--- a/src/content/topics/sdk/features/evaluating.mdx
+++ b/src/content/topics/sdk/features/evaluating.mdx
@@ -823,7 +823,7 @@ Here is an example:
 <CodeTabItem value="ruby">
 
 ```ruby
-value = client.variation("your.feature.key", user, false)
+value = client.variation("your.feature.key", { key: user.id }, false)
 ```
 
 </CodeTabItem>


### PR DESCRIPTION
While setting up the LD ruby client myself I was confused by the ruby example: `value = client.variation("your.feature.key", user, false)` because it seemed that `user` was an object. After some trial and error, and looking at the [ruby sdk docs](https://launchdarkly.github.io/ruby-server-sdk/LaunchDarkly/LDClient.html#variation-instance_method), I realized it actually needs to be a hash, and that the `key:` keyword was required. I'm updating this so that hopefully other folks are less confused in the future
