### PR TITLE
Correction to Mean

### DIFF
--- a/src/content/topics/home/experimentation-analyzing/index.mdx
+++ b/src/content/topics/home/experimentation-analyzing/index.mdx
@@ -33,7 +33,7 @@ The list below explains what each column means:
 - **Probability to be best**: The probability to be best is the likelihood that the variation has the biggest effect on the primary metric. Of all the variations in the experiment, the one with highest probability is likely the best option to choose.
 - **Relative difference from (the control)**: The relative difference from the control variation is the range that you should have 90% confidence in. For example, if the range of the relative difference is [-1%, 4%], you can have 90% confidence that the population difference is a number between 1% lower and 4% higher than the control.
 - **Credible interval**: The credible interval is the range of the value of the metric that you should have 90% confidence in. For example, if the range is [7, 34], you can have 90% confidence that the value of the metric in the population is a number between 7 and 34.
-- **Mean**: The mean is the average value of the variation in this sample. It doesn’t capture the uncertainty in the measurement, so it should not be the only measurement you use to make decisions.
+- **Mean**: The mean is the average posterior value of the variation. It doesn’t capture the uncertainty in the measurement, so it should not be the only measurement you use to make decisions.
 
 <LearnMore>
 


### PR DESCRIPTION
The mean we display is actually the mean of the posterior, not the average value of the data sent to LaunchDarkly so far. There may be a better way to phrase this - please feel free to alter the wording I suggested, if the experts have better ideas. :)

Also worth noting: this definition exists not just in the docs, but also in the hover-over tooltip of 'Mean' in the experiment results page. Not sure how to ensure that remains consistent, but happy to help if you can point me in the right direction!