### PR TITLE
Added note for RN identify

### DIFF
--- a/src/content/topics/sdk/features/identify.mdx
+++ b/src/content/topics/sdk/features/identify.mdx
@@ -389,6 +389,8 @@ To learn more, read [`identify`](https://launchdarkly.github.io/react-native-cli
 <Details summary="Expand React Native code sample">
 
 If multiple users use your app on a single device, you may want to change users and have separate flag settings for each one. To do this, the SDK stores the last five user contexts on a single device, with support for switching between different user contexts. You can use the `identify` method to switch user contexts. `identify` loads any saved flag values for the new user and immediately triggers an update of the latest flags from LaunchDarkly.
+  
+  **Note**: adding to many values in the payload of the `identify` function, can slow down the call to over 30+ seconds.
 
 Here's how:
 


### PR DESCRIPTION
<!--

Thank you for contributing to the docs!


### What to expect for PR review

When you mark your PR as ready for review, the Docs Reviewers team is automatically added as reviewers. This team is the only required reviewer.

If you need reviewers from other teams, such as your own squad, you can request them manually when you open the PR. You can also request a specific Docs team member to review your PR by adding them to the list of reviewers. You might want to do this if you've been working with a particular team member to write these docs.

For most PRs, one Docs team member will perform the review. For some larger PRs, the initial Docs team member will explicitly request review from a second Docs team member, because it's helpful to have more feedback on larger changes. In this situation, please wait for both Docs team members to approve the PR before merging. (Merging is blocked until at least one Docs team member approves.)


### What to expect for PR merge

Plan to merge your PR any time after it has been approved. It will be automatically deployed and published as soon as you merge. Depending on the change, you might want to merge your PR immediately, or you might wait until the day a feature flag is being flipped.

If you expect your PR to remain open for some time after approval, update the PR title with the expected merge date. The Docs team will periodically check in on approved PRs that have not yet been merged.

You can also schedule the merge in advance, for example if you have a firm release date planned. To learn how, read [Scheduling a PR merge to main](https://github.com/launchdarkly/git-gatsby/blob/main/README.md#internal-launchdarkly-use-only-scheduling-a-pr-merge-to-main).


### What to expect for PR deploy

All PRs are automatically deployed to production (docs.launchdarkly.com) as soon as they are merged to main. You can follow their deploy progress under GitHub Actions.

-->

I have been seeing very slow react native identify calls recently that take over 30+ second to resolve. All other LD API calls, and our own API calls resolve within under 500ms.

Working with support on a support ticket, the "solution" from support was to remove 3 of the 7 Boolean values from the identify call. Decreasing the total by only a few bytes, compared to the rest of the request.

I figured it would be good to include this in the documentation

LD Support:
> decreasing the size of the user object payload would help decrease the time identify() takes to resolve.

