### PR TITLE
Fix: Link text doesn't appear on docs 404 site

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -74,6 +74,9 @@ const linkButtonStyles: ThemeUICSSObject = {
   transition: 'background-color 0.2s ease-in-out',
   textDecoration: 'none',
   whiteSpace: 'nowrap',
+  '&:visited': {
+    color: 'grayscaleWhite',
+  },
   '&:hover': {
     backgroundColor: '#364dd9',
     color: 'grayscaleWhite',


### PR DESCRIPTION

Previously the visited styles were hiding the link text. That issue should be fixed now 

Before: 
![image](https://user-images.githubusercontent.com/14228430/186761059-c654c5bc-146d-44aa-b574-4d78cdd871a9.png)


Postfix on FF and Safari:
![Screen Shot 2022-08-25 at 1 18 16 PM](https://user-images.githubusercontent.com/14228430/186760930-9d1d9513-8404-4a7b-a0fa-2b98613e19e1.png)

