### PR TITLE
Added New Relic's instant-observability page link to LaunchDarkly

### DIFF
--- a/src/content/topics/integrations/app-performance/new-relic/events.mdx
+++ b/src/content/topics/integrations/app-performance/new-relic/events.mdx
@@ -26,7 +26,7 @@ This integration only works with a New Relic One Pro subscription. Check your su
 
 ## Overview
 
-This topic explains how to use the LaunchDarkly New Relic One integration to view LaunchDarkly events in New Relic.
+This topic explains how to use the LaunchDarkly [New Relic One integration](https://newrelic.com/instant-observability/launchdarkly/f81fac99-351c-4e50-9991-69cff5bf7798) to view LaunchDarkly events in New Relic.
 
 LaunchDarkly integrates with New Relic One. LaunchDarkly sends feature flag change events to New Relic One as deployment events. These events appear as new deployments in the [One console's APM Event log](https://docs.newrelic.com/docs/apm/apm-ui-pages/events/deployments-page-view-impact-your-app-users/).
 


### PR DESCRIPTION
Hey LaunchDarkly devs,

We have many users on our platform who are using LaunchDarkly and would like to instrument it. We’d love to provide a smooth experience for LaunchDarkly users who need to use commercial monitoring solutions, such as New Relic. Please see our documentation [here](https://newrelic.com/instant-observability/launchdarkly/f81fac99-351c-4e50-9991-69cff5bf7798).

Please consider adding a link for your direct users to provide an option for New Relic.  For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.
