### PR TITLE
correct Python Config in file loading example

### DIFF
--- a/src/content/topics/sdk/features/flags-from-files.mdx
+++ b/src/content/topics/sdk/features/flags-from-files.mdx
@@ -481,10 +481,9 @@ from ldclient.integrations import Files
 data_source_callback = Files.new_data_source(paths=["file1.json", "file2.json"],
     auto_update=True)
 
-config = Config(update_processor_class=data_source_callback, send_events=False)
+config = Config('YOUR_SDK_KEY', update_processor_class=data_source_callback, send_events=False)
 
 ldclient.set_config(config)
-ldclient.set_sdk_key("sdk key")
 client = ldclient.get()
 ```
 

--- a/src/content/topics/sdk/features/flags-from-files.mdx
+++ b/src/content/topics/sdk/features/flags-from-files.mdx
@@ -478,10 +478,10 @@ import ldclient
 from ldclient.config import Config
 from ldclient.integrations import Files
 
-data_source = Files.new_data_source(paths=["file1.json", "file2.json"],
+data_source_callback = Files.new_data_source(paths=["file1.json", "file2.json"],
     auto_update=True)
 
-config = Config(update_processor=data_source, send_events=False)
+config = Config(update_processor_class=data_source_callback, send_events=False)
 
 ldclient.set_config(config)
 ldclient.set_sdk_key("sdk key")


### PR DESCRIPTION
The Python `Config` file here was made with a `update_processor` argument that doesn't exist, but can be trivially changed to `update_processor_class` and have it work. And `sdk_key` is now a required argument on `Config`, so that was added.

There's also a renaming of `data_source` to `data_source_callback` to clarify what's being returned from `Files.new_data_source`. (I'm willing to drop that change if desired.)


<!--

Thank you for contributing to the docs!


### What to expect for PR review

When you mark your PR as ready for review, the Docs Reviewers team is automatically added as reviewers. This team is the only required reviewer.

If you need reviewers from other teams, such as your own squad, you can request them manually when you open the PR. You can also request a specific Docs team member to review your PR by adding them to the list of reviewers. You might want to do this if you've been working with a particular team member to write these docs.

For most PRs, one Docs team member will perform the review. For some larger PRs, the initial Docs team member will explicitly request review from a second Docs team member, because it's helpful to have more feedback on larger changes. In this situation, please wait for both Docs team members to approve the PR before merging. (Merging is blocked until at least one Docs team member approves.)


### What to expect for PR merge

Plan to merge your PR any time after it has been approved. It will be automatically deployed and published as soon as you merge. Depending on the change, you might want to merge your PR immediately, or you might wait until the day a feature flag is being flipped.

If you expect your PR to remain open for some time after approval, update the PR title with the expected merge date. The Docs team will periodically check in on approved PRs that have not yet been merged.

You can also schedule the merge in advance, for example if you have a firm release date planned. To learn how, read [Scheduling a PR merge to main](https://github.com/launchdarkly/git-gatsby/blob/main/README.md#internal-launchdarkly-use-only-scheduling-a-pr-merge-to-main).


### What to expect for PR deploy

All PRs are automatically deployed to production (docs.launchdarkly.com) as soon as they are merged to main. You can follow their deploy progress under GitHub Actions.

-->
