### PR TITLE
Update config-deployment.mdx

### DIFF
--- a/src/content/topics/home/accelerate/getting-started/config-deployment.mdx
+++ b/src/content/topics/home/accelerate/getting-started/config-deployment.mdx
@@ -51,7 +51,7 @@ You can set the application version to any string that includes only letters, nu
 
 To enable Accelerate to detect and report which pull requests (PRs) are part of a deployment, set the application version to one of the following options:
 
-* the full SHA of the GitHub commit for this deployment or at least a minimum of 7 chars of the SHA
+* at least the first seven characters of the SHA of the GitHub commit for this deployment
 * the tag associated with the GitHub commit for this deployment
 
 Accelerate can only associate deployments with PRs or commits if you use one of these options.

--- a/src/content/topics/home/accelerate/getting-started/config-deployment.mdx
+++ b/src/content/topics/home/accelerate/getting-started/config-deployment.mdx
@@ -51,7 +51,7 @@ You can set the application version to any string that includes only letters, nu
 
 To enable Accelerate to detect and report which pull requests (PRs) are part of a deployment, set the application version to one of the following options:
 
-* the full SHA of the GitHub commit for this deployment
+* the full SHA of the GitHub commit for this deployment or at least a minimum of 7 chars of the SHA
 * the tag associated with the GitHub commit for this deployment
 
 Accelerate can only associate deployments with PRs or commits if you use one of these options.


### PR DESCRIPTION
clarified what is required for deployment setup for Accelerate 


<!--

Thank you for contributing to the docs!

### What to expect for automatic tests

When you create a PR, GitHub automatically deploys your PR to our docs staging site, and runs a number of tests. These tests should all pass before you merge your PR.

### What to expect for PR review

When you mark your PR as ready for review, the Docs Reviewers team is automatically added as reviewers. This team is the only required reviewer.

If you need reviewers from other teams, such as your own squad, you can request them manually when you open the PR. You can also request a specific Docs team member to review your PR by adding them to the list of reviewers. You might want to do this if you've been working with a particular team member to write these docs.

For most PRs, one Docs team member will perform the review. For some larger PRs, the initial Docs team member will explicitly request review from a second Docs team member, because it's helpful to have more feedback on larger changes. In this situation, please wait for both Docs team members to approve the PR before merging. (Merging is blocked until at least one Docs team member approves.)


### What to expect for PR merge

Plan to merge your PR any time after it has been approved. It will be automatically deployed and published as soon as you merge. Depending on the change, you might want to merge your PR immediately, or you might wait until the day a feature flag is being flipped.

If you expect your PR to remain open for some time after approval, update the PR title with the expected merge date. The Docs team will periodically check in on approved PRs that have not yet been merged.

You can also schedule the merge in advance, for example if you have a firm release date planned. To learn how, read [Scheduling a PR merge to main](https://github.com/launchdarkly/ld-docs-private/blob/main/README.md#internal-launchdarkly-use-only-scheduling-a-pr-merge-to-main).


### What to expect for PR deploy

All PRs are automatically deployed to production (docs.launchdarkly.com) as soon as they are merged to main. You can follow their deploy progress under GitHub Actions.

-->
