### PR TITLE
Fix Ruby SDK v7 test data source example

### DIFF
--- a/src/content/topics/sdk/features/test-data-sources.mdx
+++ b/src/content/topics/sdk/features/test-data-sources.mdx
@@ -1056,7 +1056,7 @@ There are other ways you can configure flag behavior using a test data source. H
 ```ruby
 # This flag is true for the context key "context-key-123abc" and false for everyone else
 td.update(td.flag("flag-key-456def").
-    variation_for_key("context-key-123abc", true).
+    variation_for_user("context-key-123abc", true).
     fallthrough_variation(false))
 
 # This flag returns the string variation "green" for contexts who have the custom


### PR DESCRIPTION
The Ruby SDK v7 example for test data source was using the `variation_for_key` method but that requires 3 arguments and the example was only providing 2 so it fails with an error. It should be using `variation_for_user` which takes only 2 arguments and is described as a shortcut for the former. That latter method is also used in other language examples.