### PR TITLE
[docs] Add docs page for Chronosphere integration

### DIFF
--- a/src/content/topics/home/changelog/index.mdx
+++ b/src/content/topics/home/changelog/index.mdx
@@ -7,6 +7,23 @@ published: true
 
 This topic summarizes changes made to the LaunchDarkly documentation site. Use the table below to stay up to date on everything new in our docs.
 
+## Q4 2023
+
+<Table>
+  <TableHeader>
+    <TableHeadCell>Date</TableHeadCell>
+    <TableHeadCell>Change summary</TableHeadCell>
+    <TableHeadCell>Affected topic(s)</TableHeadCell>
+  </TableHeader>
+  <TableBody>
+  <TableRow>
+    <TableCell>December 21, 2023</TableCell>
+    <TableCell>Publishes a topic about the Chronosphere integration.</TableCell>
+    <TableCell>[Chronosphere](/integrations/chronosphere)</TableCell>
+  </TableRow>
+  </TableBody>
+</Table>
+
 ## Q2 2023
 
 <Table>
@@ -21,7 +38,7 @@ This topic summarizes changes made to the LaunchDarkly documentation site. Use t
     <TableCell>Publishes a topic about the Sentry integration.</TableCell>
     <TableCell>[Sentry](/integrations/sentry)</TableCell>
   </TableRow>
-  <TableRow>    
+  <TableRow>
     <TableCell>July 12, 2023</TableCell>
     <TableCell>Adds instructions on how to set up custom roles for Azure Security Groups.</TableCell>
     <TableCell>[Azure Active Directory](/home/account-security/azure)</TableCell>

--- a/src/content/topics/integrations/observability/chronosphere.mdx
+++ b/src/content/topics/integrations/observability/chronosphere.mdx
@@ -1,0 +1,74 @@
+---
+path: /integrations/chronosphere
+title: Chronosphere
+description: This topic explains how to configure and send LaunchDarkly events to
+Chronosphere.
+published: true
+tags: ['chronosphere', 'integration', 'event', 'observability']
+---
+
+## Overview
+
+This topic explains how to configure and send LaunchDarkly feature flag events to
+[Chronosphere](https://chronosphere.io/). These events display as change events
+within the Chronosphere Changes Explorer, and as change events on dashboards and
+query results for monitors. This integration lets you visualize more of your
+LaunchDarkly events within Chronosphere and have a single location for identifying
+anomalies across your environment.
+
+## Prerequisites
+
+To configure the Chronosphere integration, you need the following information:
+
+- **Chronosphere receiver URL**: This URL is the destination where LaunchDarkly
+  sends data to Chronosphere. The URL is structured as your Chronosphere tenant
+  URL, prefixed to the LaunchDarkly receiver endpoint. For example:
+  `https://MY_COMPANY.chronosphere.io/api/v1/data/events/receiver/launchdarkly`.
+- **Chronosphere secret token**: This credential is an API token you obtain from
+  Chronosphere Support to authenticate with Chronosphere.
+
+## Configuring the integration
+
+To configure the Chronosphere integration:
+
+1. Navigate to the [Integrations page](https://app.launchdarkly.com/default/integrations) page and find "Chronosphere".
+1. Click **Add integration**. The "Create Chronosphere configuration" panel appears.
+1. (Optional) Enter a human-readable **Name**, such as **Chronosphere**.
+1. In the **Chronosphere receiver URL** field, enter your Chronosphere receiver URL. For example, `https://MY_COMPANY.chronosphere.io/api/v1/data/events/receiver/launchdarkly`.
+1. In the **Chronosphere secret token** field, enter the API key you obtained from Chronosphere Support.
+1. (Optional) Configure a custom policy to control which information LaunchDarkly sends to Chronosphere. To learn more, see [Choosing what data to send](#choosing-what-data-to-send).
+1. After reading the Integration Terms and Conditions, check the **I have read and agree to the Integration Terms and Conditions** checkbox.
+1. Click **Save configuration**.
+
+## Choosing what data to send
+
+The "Policy" configuration field lets you control which kinds of LaunchDarkly events
+you send to Chronosphere. The default policy value restricts it to flag changes in
+production environments:
+
+<CodeSample>
+<CSTab label="Policy example">
+
+```txt
+proj/*:env/production:flag/*
+```
+
+</CSTab>
+</CodeSample>
+
+You might want to override the default policy to restrict the integration to a
+specific combination of LaunchDarkly projects and environments, or to a specific
+action or set of actions.
+
+In the following example, the policy restricts LaunchDarkly to send only changes from
+the `web-app` project's production environment to Chronosphere:
+
+<CodeSample>
+<CSTab label="Policy example">
+
+```txt
+proj/web-app:env/production:flag/*
+```
+
+</CSTab>
+</CodeSample>

--- a/src/content/topics/integrations/observability/chronosphere.mdx
+++ b/src/content/topics/integrations/observability/chronosphere.mdx
@@ -1,74 +1,22 @@
 ---
 path: /integrations/chronosphere
 title: Chronosphere
-description: This topic explains how to configure and send LaunchDarkly events to
-Chronosphere.
+description: This topic explains how to configure and send LaunchDarkly events to Chronosphere.
 published: true
-tags: ['chronosphere', 'integration', 'event', 'observability']
+tags: ['chronosphere', 'integration', 'monitoring', 'event', 'observability']
 ---
+
+<Callout intent="primary">
+<CalloutTitle>The Chronosphere integration is a Pro and Enterprise feature</CalloutTitle>
+<CalloutDescription>
+
+The Chronosphere integration is only available to customers on a Pro or Enterprise plan. To learn more, [read about our pricing](https://launchdarkly.com/pricing/). To upgrade your plan, [contact Sales](https://launchdarkly.com/contact-sales/).
+
+</CalloutDescription>
+</Callout>
 
 ## Overview
 
-This topic explains how to configure and send LaunchDarkly feature flag events to
-[Chronosphere](https://chronosphere.io/). These events display as change events
-within the Chronosphere Changes Explorer, and as change events on dashboards and
-query results for monitors. This integration lets you visualize more of your
-LaunchDarkly events within Chronosphere and have a single location for identifying
-anomalies across your environment.
+The Chronosphere LaunchDarkly integration pulls feature flag data from LaunchDarkly and displays it in the Chronosphere Changes Explorer as change events, and as change events on dashboards and query results for monitors.
 
-## Prerequisites
-
-To configure the Chronosphere integration, you need the following information:
-
-- **Chronosphere receiver URL**: This URL is the destination where LaunchDarkly
-  sends data to Chronosphere. The URL is structured as your Chronosphere tenant
-  URL, prefixed to the LaunchDarkly receiver endpoint. For example:
-  `https://MY_COMPANY.chronosphere.io/api/v1/data/events/receiver/launchdarkly`.
-- **Chronosphere secret token**: This credential is an API token you obtain from
-  Chronosphere Support to authenticate with Chronosphere.
-
-## Configuring the integration
-
-To configure the Chronosphere integration:
-
-1. Navigate to the [Integrations page](https://app.launchdarkly.com/default/integrations) page and find "Chronosphere".
-1. Click **Add integration**. The "Create Chronosphere configuration" panel appears.
-1. (Optional) Enter a human-readable **Name**, such as **Chronosphere**.
-1. In the **Chronosphere receiver URL** field, enter your Chronosphere receiver URL. For example, `https://MY_COMPANY.chronosphere.io/api/v1/data/events/receiver/launchdarkly`.
-1. In the **Chronosphere secret token** field, enter the API key you obtained from Chronosphere Support.
-1. (Optional) Configure a custom policy to control which information LaunchDarkly sends to Chronosphere. To learn more, see [Choosing what data to send](#choosing-what-data-to-send).
-1. After reading the Integration Terms and Conditions, check the **I have read and agree to the Integration Terms and Conditions** checkbox.
-1. Click **Save configuration**.
-
-## Choosing what data to send
-
-The "Policy" configuration field lets you control which kinds of LaunchDarkly events
-you send to Chronosphere. The default policy value restricts it to flag changes in
-production environments:
-
-<CodeSample>
-<CSTab label="Policy example">
-
-```txt
-proj/*:env/production:flag/*
-```
-
-</CSTab>
-</CodeSample>
-
-You might want to override the default policy to restrict the integration to a
-specific combination of LaunchDarkly projects and environments, or to a specific
-action or set of actions.
-
-In the following example, the policy restricts LaunchDarkly to send only changes from
-the `web-app` project's production environment to Chronosphere:
-
-<CodeSample>
-<CSTab label="Policy example">
-
-```txt
-proj/web-app:env/production:flag/*
-```
-
-</CSTab>
-</CodeSample>
+Chronosphere manages this integration. To learn how to use it, read Chronosphere's [LaunchDarkly Events Integration](https://docs.chronosphere.io/documentation/explore/change-events/third-party#launchdarkly).

--- a/src/content/topics/integrations/observability/chronosphere.mdx
+++ b/src/content/topics/integrations/observability/chronosphere.mdx
@@ -1,5 +1,5 @@
 ---
-path: /integrations/chronosphere
+path: /integrations/observability/chronosphere
 title: Chronosphere
 description: This topic explains how to configure and send LaunchDarkly events to Chronosphere.
 published: true


### PR DESCRIPTION
This PR adds a new page for the pending Chronosphere integration. This PR relates to [this PR](https://github.com/launchdarkly/integration-framework/pull/61) for the Chronosphere partner integration, which implements the related `manifest.json` file.

Let me know if there are other things I need to do for this PR to be reviewed. Thanks!

I followed the steps for [Running the docs site locally](https://github.com/launchdarkly/LaunchDarkly-Docs/tree/main?tab=readme-ov-file#-running-the-docs-site-locally) but can't get a local build running. When I run `yarn && yarn start`, I can open `localhost:8000` but see only this error:

<img width="831" alt="image" src="https://github.com/launchdarkly/LaunchDarkly-Docs/assets/25848033/5aeb684e-7898-4e3e-8801-94c8cabef271">